### PR TITLE
Fixed add 2 panels on the same side

### DIFF
--- a/src/Gemini/Framework/Controls/LayoutInitializer.cs
+++ b/src/Gemini/Framework/Controls/LayoutInitializer.cs
@@ -23,21 +23,21 @@ namespace Gemini.Framework.Controls
 						case PaneLocation.Left:
 						{
 							var parent = layout.Descendents().OfType<LayoutPanel>().First(d => d.Orientation == Orientation.Horizontal);
-							toolsPane = new LayoutAnchorablePane { DockWidth = new GridLength(200, GridUnitType.Pixel) };
+							toolsPane = new LayoutAnchorablePane { DockWidth = new GridLength(200, GridUnitType.Pixel), Name = paneName };
 							parent.InsertChildAt(0, toolsPane);
 						}
 							break;
 						case PaneLocation.Right:
 						{
 							var parent = layout.Descendents().OfType<LayoutPanel>().First(d => d.Orientation == Orientation.Horizontal);
-							toolsPane = new LayoutAnchorablePane { DockWidth = new GridLength(200, GridUnitType.Pixel) };
+                            toolsPane = new LayoutAnchorablePane { DockWidth = new GridLength(200, GridUnitType.Pixel), Name = paneName };
 							parent.Children.Add(toolsPane);
 						}
 							break;
 						case PaneLocation.Bottom:
 						{
 							var parent = layout.Descendents().OfType<LayoutPanel>().First(d => d.Orientation == Orientation.Vertical);
-							toolsPane = new LayoutAnchorablePane { DockHeight = new GridLength(200, GridUnitType.Pixel) };
+                            toolsPane = new LayoutAnchorablePane { DockHeight = new GridLength(200, GridUnitType.Pixel), Name = paneName };
 							parent.Children.Add(toolsPane);
 						}
 							break;


### PR DESCRIPTION
I've found a problem when you add 2 panels during initialization. Both panels will be visible next to each other instead of 2 tabs in 1 panel. It is because the name is not set during initialization. This pull request fixes that.
