### PR TITLE
Guard against null MainMenu items

### DIFF
--- a/src/Gemini.Demo/Modules/Settings/Module.cs
+++ b/src/Gemini.Demo/Modules/Settings/Module.cs
@@ -14,8 +14,11 @@ namespace Gemini.Demo.Modules.Settings
 	{
 		public override void Initialize()
 		{
-            MainMenu.All.First(x => x.Name == "View")
-                .Add(new MenuItem("Settings", OpenSettings));
+            if (MainMenu.All.FirstOrDefault(x => x.Name == "View") != null)
+            {
+                MainMenu.All.First(x => x.Name == "View")
+                    .Add(new MenuItem("Settings", OpenSettings));
+            }
 		}
 
 		private IEnumerable<IResult> OpenSettings()

--- a/src/Gemini.Demo/Modules/Startup/Module.cs
+++ b/src/Gemini.Demo/Modules/Startup/Module.cs
@@ -58,8 +58,11 @@ namespace Gemini.Demo.Modules.Startup
 
 			_output.AppendLine("Started up");
 
-            MainMenu.All.First(x => x.Name == "View")
-                .Add(new MenuItem("History", OpenHistory));
+            if(MainMenu.All.FirstOrDefault(x => x.Name == "View") != null)
+            {
+                MainMenu.All.First(x => x.Name == "View")
+                    .Add(new MenuItem("History", OpenHistory));
+            }
 
 		    Shell.ActiveDocumentChanged += (sender, e) => RefreshInspector();
 		    RefreshInspector();

--- a/src/Gemini.Modules.ErrorList/Module.cs
+++ b/src/Gemini.Modules.ErrorList/Module.cs
@@ -13,8 +13,11 @@ namespace Gemini.Modules.ErrorList
     {
         public override void Initialize()
         {
-            MainMenu.All.First(x => x.Name == "View")
-                .Add(new MenuItem("Error List", OpenErrorList));
+            if (MainMenu.All.FirstOrDefault(x => x.Name == "View") != null)
+            {
+                MainMenu.All.First(x => x.Name == "View")
+                    .Add(new MenuItem("Error List", OpenErrorList));
+            }
         }
 
         private static IEnumerable<IResult> OpenErrorList()

--- a/src/Gemini.Modules.Inspector/Module.cs
+++ b/src/Gemini.Modules.Inspector/Module.cs
@@ -13,8 +13,11 @@ namespace Gemini.Modules.Inspector
 	{
 		public override void Initialize()
 		{
-			MainMenu.All.First(x => x.Name == "View")
-				.Add(new MenuItem("Inspector", OpenInspector));
+            if (MainMenu.All.FirstOrDefault(x => x.Name == "View") != null)
+            {
+			    MainMenu.All.First(x => x.Name == "View")
+				    .Add(new MenuItem("Inspector", OpenInspector));
+            }
 		}
 
 		private static IEnumerable<IResult> OpenInspector()

--- a/src/Gemini.Modules.Output/Module.cs
+++ b/src/Gemini.Modules.Output/Module.cs
@@ -13,8 +13,11 @@ namespace Gemini.Modules.Output
 	{
 		public override void Initialize()
 		{
-            MainMenu.All.First(x => x.Name == "View")
-				.Add(new MenuItem("Output", OpenOutput));
+            if (MainMenu.All.FirstOrDefault(x => x.Name == "View") != null)
+            {
+                MainMenu.All.First(x => x.Name == "View")
+				    .Add(new MenuItem("Output", OpenOutput));
+            } 
         }
 
         private IEnumerable<IResult> OpenOutput()

--- a/src/Gemini.Modules.PropertyGrid/Module.cs
+++ b/src/Gemini.Modules.PropertyGrid/Module.cs
@@ -14,8 +14,11 @@ namespace Gemini.Modules.PropertyGrid
 	{
 		public override void Initialize()
 		{
-			MainMenu.All.First(x => x.Name == "View")
-				.Add(new MenuItem("Properties", OpenProperties).WithIcon());
+            if (MainMenu.All.FirstOrDefault(x => x.Name == "View") != null)
+            {
+			    MainMenu.All.First(x => x.Name == "View")
+				    .Add(new MenuItem("Properties", OpenProperties).WithIcon());
+            }
 		}
 
 		private static IEnumerable<IResult> OpenProperties()

--- a/src/Gemini/Modules/Shell/Module.cs
+++ b/src/Gemini/Modules/Shell/Module.cs
@@ -11,8 +11,11 @@ namespace Gemini.Modules.Shell
 	{
 		public override void Initialize()
 		{
-			((StandardMenuItem) MainMenu.All.First(x => x.Name == "Open"))
-				.WithGlobalShortcut(ModifierKeys.Control, Key.O);
+            if (MainMenu.All.FirstOrDefault(x => x.Name == "Open") != null)
+            {
+			    ((StandardMenuItem) MainMenu.All.First(x => x.Name == "Open"))
+				    .WithGlobalShortcut(ModifierKeys.Control, Key.O);
+            }
 		}
 	}
 }

--- a/src/Gemini/Modules/Toolbox/Module.cs
+++ b/src/Gemini/Modules/Toolbox/Module.cs
@@ -13,8 +13,11 @@ namespace Gemini.Modules.Toolbox
     {
         public override void Initialize()
         {
-            MainMenu.All.First(x => x.Name == "View")
-                .Add(new MenuItem("Toolbox", OpenToolbox));
+            if (MainMenu.All.FirstOrDefault(x => x.Name == "View") != null)
+            {
+                MainMenu.All.First(x => x.Name == "View")
+                    .Add(new MenuItem("Toolbox", OpenToolbox));
+            }
         }
 
         private static IEnumerable<IResult> OpenToolbox()


### PR DESCRIPTION
Allows MainMenu.Clear() on Initialize() to "hide" MainMenu.
