### PR TITLE
DataTemplateSelectors in GraphControl

### DIFF
--- a/src/Gemini.Modules.GraphEditor/Controls/ElementItemsControl.cs
+++ b/src/Gemini.Modules.GraphEditor/Controls/ElementItemsControl.cs
@@ -19,5 +19,7 @@ namespace Gemini.Modules.GraphEditor.Controls
         {
             SelectionMode = SelectionMode.Extended;
         }
+
+    
     }
 }

--- a/src/Gemini.Modules.GraphEditor/Controls/GraphControl.cs
+++ b/src/Gemini.Modules.GraphEditor/Controls/GraphControl.cs
@@ -48,6 +48,24 @@ namespace Gemini.Modules.GraphEditor.Controls
             set { SetValue(ElementItemTemplateProperty, value); }
         }
 
+        public static readonly DependencyProperty ElementItemDataTemplateSelectorProperty = DependencyProperty.Register(
+            "ElementItemDataTemplateSelector", typeof (DataTemplateSelector), typeof (GraphControl), new PropertyMetadata(default(DataTemplateSelector)));
+
+        public DataTemplateSelector ElementItemDataTemplateSelector
+        {
+            get { return (DataTemplateSelector) GetValue(ElementItemDataTemplateSelectorProperty); }
+            set { SetValue(ElementItemDataTemplateSelectorProperty, value); }
+        }
+
+        public static readonly DependencyProperty ConnectionItemDataTemplateSelectorProperty = DependencyProperty.Register(
+            "ConnectionItemDataTemplateSelector", typeof (DataTemplateSelector), typeof (GraphControl), new PropertyMetadata(default(DataTemplateSelector)));
+
+        public DataTemplateSelector ConnectionItemDataTemplateSelector
+        {
+            get { return (DataTemplateSelector) GetValue(ConnectionItemDataTemplateSelectorProperty); }
+            set { SetValue(ConnectionItemDataTemplateSelectorProperty, value); }
+        }
+
         public static readonly DependencyProperty ConnectionsSourceProperty = DependencyProperty.Register(
             "ConnectionsSource", typeof(IEnumerable), typeof(GraphControl));
 


### PR DESCRIPTION
Added ElementItemDataTemplateSelector and ConnectionItemDataTemplateSelector dependency properties to be able to use a DataTemplateSelector for different appearances of nodes and connections in the GraphControl.

Don't know why it detects in ElementItemsControl.cs. I guess I did something wrong...
