### PR TITLE
Update MenuItem.cs

### DIFF
--- a/src/Gemini/Modules/MainMenu/Models/MenuItem.cs
+++ b/src/Gemini/Modules/MainMenu/Models/MenuItem.cs
@@ -44,7 +44,7 @@ namespace Gemini.Modules.MainMenu.Models
 
 		public IEnumerable<IResult> Execute()
 		{
-			return _execute != null ? _execute() : new IResult[] { };
+			return _execute != null && CanExecute ? _execute() : new IResult[] { };
 		}
 	}
 }


### PR DESCRIPTION
Added the " && CanExecute" clause in the Execute function in order to prevent the Execute function to be performed should the CanExecute property be false. This is a proposed fix for issue #69.
