### PR TITLE
Update ToolBarItem.cs

### DIFF
--- a/src/Gemini/Modules/ToolBars/Models/ToolBarItem.cs
+++ b/src/Gemini/Modules/ToolBars/Models/ToolBarItem.cs
@@ -32,7 +32,7 @@ namespace Gemini.Modules.ToolBars.Models
 
 		public IEnumerable<IResult> Execute()
 		{
-			return _execute != null ? _execute() : new IResult[] { };
+			return _execute != null && CanExecute ? _execute() : new IResult[] { };
 		}
 	}
 }


### PR DESCRIPTION
Added the " && CanExecute" clause in the Execute function in order to prevent the Execute function to be performed should the CanExecute property be false. This is a proposed fix for issue #69.
