### PR TITLE
Addresses issue #129 , Default Menu Customization

### DIFF
--- a/src/Gemini/Framework/Menus/ExcludeMenuDefinition.cs
+++ b/src/Gemini/Framework/Menus/ExcludeMenuDefinition.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gemini.Framework.Menus
+{
+    public class ExcludeMenuDefinition
+    {
+        private MenuDefinition _menuDefinitionToExclude;
+        public MenuDefinition MenuDefinitionToExclude 
+        { 
+            get { return _menuDefinitionToExclude; } 
+        }
+
+        private string _menuDefinitionToExcludeText;
+        public string MenuDefinitionToExcludeText
+        {
+            get { return _menuDefinitionToExcludeText; }
+        }
+
+        public ExcludeMenuDefinition(MenuDefinition menuDefinition)
+        {
+            _menuDefinitionToExclude = menuDefinition;
+            _menuDefinitionToExcludeText = menuDefinition.Text;
+        }
+    }
+}

--- a/src/Gemini/Framework/Menus/ExcludeMenuItemDefinition.cs
+++ b/src/Gemini/Framework/Menus/ExcludeMenuItemDefinition.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gemini.Framework.Menus
+{
+    public class ExcludeMenuItemDefinition
+    {
+        private MenuItemDefinition _menuItemDefinitionToExclude;
+        public MenuItemDefinition MenuItemDefinitionToExclude 
+        { 
+            get { return _menuItemDefinitionToExclude; } 
+        }
+
+        private string _menuItemDefinitionToExcludeText;
+        public string MenuItemDefinitionToExcludeText
+        {
+            get { return _menuItemDefinitionToExcludeText; }
+        }
+
+        public ExcludeMenuItemDefinition(MenuItemDefinition menuItemDefinition)
+        {
+            _menuItemDefinitionToExclude = menuItemDefinition;
+            _menuItemDefinitionToExcludeText = menuItemDefinition.Text;
+        }
+    }
+}

--- a/src/Gemini/Framework/Menus/ExcludeMenuItemGroupDefinition.cs
+++ b/src/Gemini/Framework/Menus/ExcludeMenuItemGroupDefinition.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gemini.Framework.Menus
+{
+    public class ExcludeMenuItemGroupDefinition
+    {
+        private MenuItemGroupDefinition _menuItemGroupDefinitionToExclude;
+        public MenuItemGroupDefinition MenuItemGroupDefinitionToExclude 
+        {
+            get { return _menuItemGroupDefinitionToExclude; }
+        }
+
+        private string _menuItemGroupDefinitionToExcludeParentText;
+        public string MenuItemGroupDefinitionToExcludeParentText
+        {
+            get { return _menuItemGroupDefinitionToExcludeParentText; }
+        }
+
+        public ExcludeMenuItemGroupDefinition(MenuItemGroupDefinition menuItemGroupDefinition)
+        {
+            _menuItemGroupDefinitionToExclude = menuItemGroupDefinition;
+            _menuItemGroupDefinitionToExcludeParentText = menuItemGroupDefinition.Parent.Text;
+        }
+    }
+}

--- a/src/Gemini/Gemini.csproj
+++ b/src/Gemini/Gemini.csproj
@@ -120,6 +120,9 @@
     <Compile Include="Framework\IExecutableItem.cs" />
     <Compile Include="Framework\ILayoutItem.cs" />
     <Compile Include="Framework\Menus\CommandMenuItemDefinition.cs" />
+    <Compile Include="Framework\Menus\ExcludeMenuDefinition.cs" />
+    <Compile Include="Framework\Menus\ExcludeMenuItemDefinition.cs" />
+    <Compile Include="Framework\Menus\ExcludeMenuItemGroupDefinition.cs" />
     <Compile Include="Framework\Menus\MenuBarDefinition.cs" />
     <Compile Include="Framework\Menus\MenuDefinition.cs" />
     <Compile Include="Framework\Menus\MenuDefinitionBase.cs" />


### PR DESCRIPTION
Added ExcludeMenu<xx> classes to Gemini.Framework.Menus and made edits to the Gemini.Modules.MainMenu MenuBuilder class. 

This means exported ExcludeMenu<xx> classes will remove those menu options from the default definitions file in the MainMenu module.

Example usage with the Gemini Demo project is as follows:

```c#
public static class ExcludeMenuDefinitions
    {
        [Export]
        public static ExcludeMenuItemDefinition ExcludeOpenMenuItem = new ExcludeMenuItemDefinition(Gemini.Modules.Shell.MenuDefinitions.FileOpenMenuItem);

        [Export]
        public static ExcludeMenuItemGroupDefinition ExcludeWindowMenuItemGroup = new ExcludeMenuItemGroupDefinition(Gemini.Modules.MainMenu.MenuDefinitions.ViewToolsMenuGroup);

        [Export]
        public static ExcludeMenuDefinition ExcludeWindowMenuDefinition = new ExcludeMenuDefinition(Gemini.Modules.MainMenu.MenuDefinitions.WindowMenu);
    }
```