### PR TITLE
Update projects that reference the deprecated Roslyn.Compilers package

### DIFF
--- a/src/Gemini.Demo/Gemini.Demo.csproj
+++ b/src/Gemini.Demo/Gemini.Demo.csproj
@@ -65,19 +65,27 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AvalonEdit.5.0.2\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>
     </Reference>
-    <Reference Include="Roslyn.Compilers, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Roslyn.Compilers.Common.1.2.20906.2\lib\net45\Roslyn.Compilers.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Roslyn.Compilers.CSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Roslyn.Compilers.CSharp.1.2.20906.2\lib\net45\Roslyn.Compilers.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml" />
@@ -300,7 +308,10 @@
   <ItemGroup>
     <Effect Include="Modules\FilterDesigner\ShaderEffects\MultiplyEffect.fx" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EffectCompile" Condition="'@(Effect)' != '' ">

--- a/src/Gemini.Demo/packages.config
+++ b/src/Gemini.Demo/packages.config
@@ -6,6 +6,9 @@
   <package id="Extended.Wpf.Toolkit" version="2.5" targetFramework="net45" />
   <package id="HelixToolkit" version="2015.1.601" targetFramework="net45" />
   <package id="HelixToolkit.Wpf" version="2015.1.601" targetFramework="net45" />
-  <package id="Roslyn.Compilers.Common" version="1.2.20906.2" targetFramework="net45" />
-  <package id="Roslyn.Compilers.CSharp" version="1.2.20906.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />
 </packages>

--- a/src/Gemini.Modules.CodeCompiler/CodeCompiler.cs
+++ b/src/Gemini.Modules.CodeCompiler/CodeCompiler.cs
@@ -8,8 +8,10 @@ using Gemini.Framework.Results;
 using Gemini.Framework.Services;
 using Gemini.Modules.ErrorList;
 using Gemini.Modules.Output;
-using Roslyn.Compilers;
-using Roslyn.Compilers.CSharp;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.IO;
+using Microsoft.CodeAnalysis.Emit;
 
 namespace Gemini.Modules.CodeCompiler
 {
@@ -33,56 +35,49 @@ namespace Gemini.Modules.CodeCompiler
             _output.AppendLine("------ Compile started");
 
             GC.Collect();
+            var compilation = CSharpCompilation.Create(outputName)
+                       .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                       .AddReferences(references)
+                       .AddSyntaxTrees(syntaxTrees);
 
-            var compilation = Compilation.Create(outputName)
-                .WithOptions(new CompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-                .AddReferences(references)
-                .AddSyntaxTrees(syntaxTrees);
-
-            var moduleBuilder = AppDomain.CurrentDomain
-                .DefineDynamicAssembly(new AssemblyName(outputName),
-                    AssemblyBuilderAccess.RunAndCollect)
-                .DefineDynamicModule(outputName);
-
-            var result = compilation.Emit(moduleBuilder);
-
-            ProcessResult(result);
-
-            _output.AppendLine("------ Compile finished");
-
-            return moduleBuilder.Assembly;
+            using (var ms = new MemoryStream())
+            {
+                var result = compilation.Emit(ms);
+                _errorList.Items.Clear();
+                if (!result.Success)
+                {
+                    ProcessResult(result);
+                    _output.AppendLine("------ Compile failed");
+                    return null;
+                }
+                _output.AppendLine("------ Compile finished");
+                ms.Seek(0, SeekOrigin.Begin);
+                return Assembly.Load(ms.ToArray());
+            }
         }
 
-        private void ProcessResult(ReflectionEmitResult result)
+        private void ProcessResult(EmitResult result)
         {
-            _errorList.Items.Clear();
-
-            if (!result.Success)
+            foreach (var diagnostic in result.Diagnostics)
             {
-                foreach (var diagnostic in result.Diagnostics)
+                if (!diagnostic.Location.IsInSource)
                 {
-                    if (!diagnostic.Location.IsInSource)
-                        throw new NotSupportedException("Only support source file locations.");
-
-                    var itemType = GetItemType(diagnostic.Info.Severity);
-                    var description = diagnostic.Info.GetMessage();
-                    var lineSpan = diagnostic.Location.GetLineSpan(false);
-
-                    _errorList.AddItem(itemType, description,
-                        lineSpan.Path,
-                        lineSpan.StartLinePosition.Line,
-                        lineSpan.StartLinePosition.Character,
-                        () =>
-                        {
-                            var openDocumentResult = new OpenDocumentResult(lineSpan.Path);
-                            IoC.BuildUp(openDocumentResult);
-                            openDocumentResult.Execute(null);
-                        });
+                    throw new NotSupportedException("Only support source file locations.");
                 }
+                var itemType = GetItemType(diagnostic.Severity);
+                var description = diagnostic.GetMessage();
+                var lineSpan = diagnostic.Location.GetLineSpan();
+                _errorList.AddItem(itemType, description,
+                    lineSpan.Path,
+                    lineSpan.StartLinePosition.Line,
+                    lineSpan.StartLinePosition.Character,
+                    () =>
+                    {
+                        var openDocumentResult = new OpenDocumentResult(lineSpan.Path);
+                        IoC.BuildUp(openDocumentResult);
+                        openDocumentResult.Execute(null);
+                    });
             }
-
-            if (result.IsUncollectible)
-                _errorList.AddItem(ErrorListItemType.Message, "The compiled assembly is not garbage collectible.");
         }
 
         private static ErrorListItemType GetItemType(DiagnosticSeverity severity)

--- a/src/Gemini.Modules.CodeCompiler/Gemini.Modules.CodeCompiler.csproj
+++ b/src/Gemini.Modules.CodeCompiler/Gemini.Modules.CodeCompiler.csproj
@@ -43,15 +43,25 @@
       <HintPath>..\packages\Caliburn.Micro.2.0.2\lib\net45\Caliburn.Micro.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Roslyn.Compilers">
-      <HintPath>..\packages\Roslyn.Compilers.Common.1.2.20906.2\lib\net45\Roslyn.Compilers.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Roslyn.Compilers.CSharp">
-      <HintPath>..\packages\Roslyn.Compilers.CSharp.1.2.20906.2\lib\net45\Roslyn.Compilers.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -83,6 +93,10 @@
       <Project>{13DBFC87-C152-4A86-94B0-D9944BEEF647}</Project>
       <Name>Gemini</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/Gemini.Modules.CodeCompiler/ICodeCompiler.cs
+++ b/src/Gemini.Modules.CodeCompiler/ICodeCompiler.cs
@@ -1,14 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
 using System.Reflection;
-using Roslyn.Compilers;
-using Roslyn.Compilers.CSharp;
 
 namespace Gemini.Modules.CodeCompiler
 {
     public interface ICodeCompiler
     {
         Assembly Compile(
-            IEnumerable<SyntaxTree> syntaxTrees, 
+            IEnumerable<SyntaxTree> syntaxTrees,
             IEnumerable<MetadataReference> references,
             string outputName);
     }

--- a/src/Gemini.Modules.CodeCompiler/packages.config
+++ b/src/Gemini.Modules.CodeCompiler/packages.config
@@ -2,6 +2,9 @@
 <packages>
   <package id="Caliburn.Micro" version="2.0.2" targetFramework="net45" />
   <package id="Caliburn.Micro.Core" version="2.0.2" targetFramework="net45" />
-  <package id="Roslyn.Compilers.Common" version="1.2.20906.2" targetFramework="net45" />
-  <package id="Roslyn.Compilers.CSharp" version="1.2.20906.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Update Gemini.Demo and Gemini.Modules.CodeCompiler to reference Microsoft.CodeAnalysis.CSharp -Version 1.0.0.
Made all the necessary API call changes to CodeCompiler.cs and HelixViewModel.cs 
The CodeCompiler module can now be used to compile C#6 code
