### PR TITLE
Shell: Create default documents and tools if persisted layout state could not be loaded

### DIFF
--- a/src/Gemini/Modules/Shell/Services/ILayoutItemStatePersister.cs
+++ b/src/Gemini/Modules/Shell/Services/ILayoutItemStatePersister.cs
@@ -5,7 +5,7 @@ namespace Gemini.Modules.Shell.Services
 {
     public interface ILayoutItemStatePersister
     {
-        void SaveState(IShell shell, IShellView shellView, string fileName);
-        void LoadState(IShell shell, IShellView shellView, string fileName);
+        bool SaveState(IShell shell, IShellView shellView, string fileName);
+        bool LoadState(IShell shell, IShellView shellView, string fileName);
     }
 }

--- a/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
+++ b/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
@@ -13,7 +13,7 @@ namespace Gemini.Modules.Shell.Services
     [Export(typeof(ILayoutItemStatePersister))]
     public class LayoutItemStatePersister : ILayoutItemStatePersister
     {
-        public void SaveState(IShell shell, IShellView shellView, string fileName)
+        public bool SaveState(IShell shell, IShellView shellView, string fileName)
         {
             FileStream stream = null;
 
@@ -119,11 +119,17 @@ namespace Gemini.Modules.Shell.Services
             }
             catch
             {
+                return false;
+            }
+            finally
+            {
                 if (stream != null)
                 {
                     stream.Dispose();
                 }
             }
+
+            return true;
         }
 
         Type GetTypeFromContractNameAsILayoutItem(ExportAttribute attribute)
@@ -141,13 +147,13 @@ namespace Gemini.Modules.Shell.Services
             return type;
         }
 
-        public void LoadState(IShell shell, IShellView shellView, string fileName)
+        public bool LoadState(IShell shell, IShellView shellView, string fileName)
         {
             var layoutItems = new Dictionary<string, ILayoutItem>();
 
             if (!File.Exists(fileName))
             {
-                return;
+                return false;
             }
 
             FileStream stream = null;
@@ -204,11 +210,16 @@ namespace Gemini.Modules.Shell.Services
             }
             catch
             {
-                if (stream != null)
-                {
+                return false;
+            }
+            finally
+            {
+                if (stream != null) {
                     stream.Close();
                 }
             }
+
+            return true;
         }
     }
 }

--- a/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
+++ b/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
@@ -135,16 +135,12 @@ namespace Gemini.Modules.Shell.ViewModels
 	            _themeManager.SetCurrentTheme(Properties.Settings.Default.ThemeName);
 
             _shellView = (IShellView)view;
-            if (!HasPersistedState)
+            if (!_layoutItemStatePersister.LoadState(this, _shellView, StateFile))
             {
                 foreach (var defaultDocument in _modules.SelectMany(x => x.DefaultDocuments))
                     OpenDocument(defaultDocument);
                 foreach (var defaultTool in _modules.SelectMany(x => x.DefaultTools))
                     ShowTool((ITool)IoC.GetInstance(defaultTool, null));
-            }
-            else
-            {
-                _layoutItemStatePersister.LoadState(this, _shellView, StateFile);
             }
 
             foreach (var module in _modules)


### PR DESCRIPTION
If loading the persisted layout state fails, you get an empty shell. This makes the function return a status instead and if it failed the shell will create the default documents and tools.