### PR TITLE
Inspector: Make nested collapsible groups more pretty

### DIFF
--- a/src/Gemini.Modules.Inspector/Inspectors/CollapsibleGroupView.xaml
+++ b/src/Gemini.Modules.Inspector/Inspectors/CollapsibleGroupView.xaml
@@ -13,7 +13,11 @@
 		<gemini:ExpanderEx Header="{Binding Name, FallbackValue='Test'}" 
                            IsExpanded="{Binding IsExpanded}">
             <ItemsControl ItemsSource="{Binding Children}" 
-                          ItemTemplateSelector="{StaticResource InspectorItemTemplateSelector}" />
+                          ItemTemplateSelector="{StaticResource InspectorItemTemplateSelector}" Margin="10,0,0,0" BorderThickness="1,0,0,0" >
+                <ItemsControl.BorderBrush>
+                    <SolidColorBrush Color="{DynamicResource {x:Static SystemColors.ActiveBorderColorKey}}"/>
+                </ItemsControl.BorderBrush>
+            </ItemsControl>
         </gemini:ExpanderEx>
     </Grid>
 </UserControl>


### PR DESCRIPTION
This adds a margin to collapsible groups to make nested groups look less flat.
It also adds a border on the left side to have a clear differentiation between nesting levels.
