### PR TITLE
Bootstrapper: Add possibility to run code before Initialize

### DIFF
--- a/src/Gemini/AppBootstrapper.cs
+++ b/src/Gemini/AppBootstrapper.cs
@@ -25,7 +25,12 @@ namespace Gemini
 
         public AppBootstrapper()
         {
+            this.PreInitialize();
             this.Initialize();
+        }
+
+        protected virtual void PreInitialize()
+        {
         }
 
 		/// <summary>


### PR DESCRIPTION
Sometimes you need to run code before the initialization of the bootstrapper.
One use case for example is to install an assembly resolver to load assemblies from non default locations.
This patch adds a virtual PreInitialize function to the bootstrapper that can be overridden in subclasses to do this.
