### PR TITLE
Inspector: Check return values for Focus and CaptureMouse

### DIFF
--- a/src/Gemini.Modules.Inspector/Controls/ScreenColorPicker.cs
+++ b/src/Gemini.Modules.Inspector/Controls/ScreenColorPicker.cs
@@ -70,11 +70,14 @@ namespace Gemini.Modules.Inspector.Controls
                     _bitmap.Dispose();
                 _bitmap = NativeMethods.GetDesktop();
 
-                RaisePickingStarted(EventArgs.Empty);
-
-                Focus(); // So that we get the Escape key.
-                CaptureMouse();
-                _timer.Start();
+                if (Focus()) // So that we get the Escape key.
+                {
+                    if (CaptureMouse())
+                    {
+                        RaisePickingStarted(EventArgs.Empty);
+                        _timer.Start();
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
Do not raise the PickingStarted event or start the timer if they fail.