### PR TITLE
ThemeManager: Make Theme list modifyable and theme functions virtual

### DIFF
--- a/src/Gemini/Framework/Themes/BlueTheme.cs
+++ b/src/Gemini/Framework/Themes/BlueTheme.cs
@@ -24,12 +24,12 @@ namespace Gemini.Framework.Themes
     [Export(typeof(ITheme))]
     public class BlueTheme : ITheme
     {
-        public string Name
+        public virtual string Name
         {
             get { return "Blue"; }
         }
 
-        public IEnumerable<Uri> ApplicationResources
+        public virtual IEnumerable<Uri> ApplicationResources
         {
             get
             {
@@ -38,7 +38,7 @@ namespace Gemini.Framework.Themes
             }
         }
 
-        public IEnumerable<Uri> MainWindowResources
+        public virtual IEnumerable<Uri> MainWindowResources
         {
             get { yield break; }
         }

--- a/src/Gemini/Framework/Themes/DarkTheme.cs
+++ b/src/Gemini/Framework/Themes/DarkTheme.cs
@@ -24,12 +24,12 @@ namespace Gemini.Framework.Themes
     [Export(typeof(ITheme))]
     public class DarkTheme : ITheme
     {
-        public string Name
+        public virtual string Name
         {
             get { return "Dark"; }
         }
 
-        public IEnumerable<Uri> ApplicationResources
+        public virtual IEnumerable<Uri> ApplicationResources
         {
             get
             {
@@ -38,7 +38,7 @@ namespace Gemini.Framework.Themes
             }
         }
 
-        public IEnumerable<Uri> MainWindowResources
+        public virtual IEnumerable<Uri> MainWindowResources
         {
             get { yield break; }
         }

--- a/src/Gemini/Framework/Themes/IThemeManager.cs
+++ b/src/Gemini/Framework/Themes/IThemeManager.cs
@@ -24,7 +24,7 @@ namespace Gemini.Framework.Themes
     {
         event EventHandler CurrentThemeChanged;
 
-        IEnumerable<ITheme> Themes { get; }
+        List<ITheme> Themes { get; }
         ITheme CurrentTheme { get; }
 
         bool SetCurrentTheme(string name);

--- a/src/Gemini/Framework/Themes/LightTheme.cs
+++ b/src/Gemini/Framework/Themes/LightTheme.cs
@@ -24,12 +24,12 @@ namespace Gemini.Framework.Themes
     [Export(typeof(ITheme))]
     public class LightTheme : ITheme
     {
-        public string Name
+        public virtual string Name
         {
             get { return "Light"; }
         }
 
-        public IEnumerable<Uri> ApplicationResources
+        public virtual IEnumerable<Uri> ApplicationResources
         {
             get
             {
@@ -38,7 +38,7 @@ namespace Gemini.Framework.Themes
             }
         }
 
-        public IEnumerable<Uri> MainWindowResources
+        public virtual IEnumerable<Uri> MainWindowResources
         {
             get { yield break; }
         }

--- a/src/Gemini/Framework/Themes/ThemeManager.cs
+++ b/src/Gemini/Framework/Themes/ThemeManager.cs
@@ -34,11 +34,9 @@ namespace Gemini.Framework.Themes
 
         private ResourceDictionary _applicationResourceDictionary;
 
-        private readonly ITheme[] _themes;
-
-        public IEnumerable<ITheme> Themes
+        public List<ITheme> Themes
         {
-            get { return _themes; }
+            get; private set;
         }
 
         public ITheme CurrentTheme { get; private set; }
@@ -46,13 +44,13 @@ namespace Gemini.Framework.Themes
         [ImportingConstructor]
         public ThemeManager([ImportMany] ITheme[] themes)
         {
-            _themes = themes;
+            Themes = new List<ITheme>(themes);
             _settingsEventManager.AddListener(s => s.ThemeName, value => SetCurrentTheme(value));
         }
 
         public bool SetCurrentTheme(string name)
         {
-            var theme = _themes.FirstOrDefault(x => x.Name == name);
+            var theme = Themes.FirstOrDefault(x => x.Name == name);
             if (theme == null)
                 return false;
 


### PR DESCRIPTION
This makes it possible to clear the list of themes on startup before the
shell is loaded and add custom themes derived from the Gemini base themes.

Example code:
```c#
[Export(typeof(ITheme))]
public class LightTheme : Gemini.Framework.Themes.LightTheme
{
	public override IEnumerable<Uri> ApplicationResources
	{
		get {
			foreach (var res in base.ApplicationResources)
				yield return res;
			yield return new Uri("pack://application:,,,/InteractiveAsia;component/Themes/LightTheme.xaml");
		}
	}
}

/* Remove default themes, add our derived themes */
_themeManager.Themes.Clear();
_themeManager.Themes.Add(new MyThemes.LightTheme());
_themeManager.Themes.Add(new MyThemes.BlueTheme());
_themeManager.Themes.Add(new MyThemes.DarkTheme());
```
Signed-off-by: Axel Gembe <axel@gembe.net>