### PR TITLE
Shell: Do not raise ActiveDocumentChanging if same document gets activated again

### DIFF
--- a/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
+++ b/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
@@ -180,14 +180,16 @@ namespace Gemini.Modules.Shell.ViewModels
             if (_closing)
                 return;
 
+            if (ReferenceEquals(item, ActiveItem))
+                return;
+
             RaiseActiveDocumentChanging();
 
             var currentActiveItem = ActiveItem;
 
             base.ActivateItem(item);
 
-            if (!ReferenceEquals(item, currentActiveItem))
-                RaiseActiveDocumentChanged();
+            RaiseActiveDocumentChanged();
         }
 
 	    private void RaiseActiveDocumentChanging()


### PR DESCRIPTION
There are problems with writing code that opens and closes windows based
on the active document if the ActiveDocumentChanging event occurs when the
same document is activated again. In my case I opened a new tool window
which would disappear right after ShowTool because it would raise
ActiveDocumentChanging with the same document again.

Signed-off-by: Axel Gembe <axel@gembe.net>