### PR TITLE
SettingsView: Fix design time exception in BindableTreeViewSelectedItemBehavior

### DIFF
--- a/src/Gemini/Framework/Behaviors/BindableTreeViewSelectedItemBehavior.cs
+++ b/src/Gemini/Framework/Behaviors/BindableTreeViewSelectedItemBehavior.cs
@@ -37,6 +37,9 @@ namespace Gemini.Framework.Behaviors
             if (tvi == null)
             {
                 var tree = ((BindableTreeViewSelectedItemBehavior) sender).AssociatedObject;
+                if (tree == null)
+                    return;
+
                 if (!tree.IsLoaded)
                 {
                     RoutedEventHandler handler = null;


### PR DESCRIPTION
Fix BindableTreeViewSelectedItemBehavior to check for tree being null.

Signed-off-by: Axel Gembe <axel@gembe.net>