### PR TITLE
Inspector: Make RangeEditor not update the undo manager when dragging

### DIFF
--- a/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
+++ b/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
@@ -111,6 +111,7 @@
       <DependentUpon>CollapsibleGroupView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Inspectors\BitmapSourceEditorViewModel.cs" />
+    <Compile Include="Inspectors\SelectiveUndoEditorBase.cs" />
     <Compile Include="Inspectors\ILabelledInspector.cs" />
     <Compile Include="Inspectors\TextBoxEditorView.xaml.cs">
       <DependentUpon>TextBoxEditorView.xaml</DependentUpon>

--- a/src/Gemini.Modules.Inspector/Inspectors/ChangeObjectValueAction.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/ChangeObjectValueAction.cs
@@ -19,10 +19,14 @@ namespace Gemini.Modules.Inspector.Inspectors
             }
         }
 
-        public ChangeObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, object newValue)
+        public ChangeObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, object newValue) :
+            this(boundPropertyDescriptor, boundPropertyDescriptor.Value, newValue)
+        { }
+
+        public ChangeObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, object originalValue, object newValue)
         {
             _boundPropertyDescriptor = boundPropertyDescriptor;
-            _originalValue = boundPropertyDescriptor.Value;
+            _originalValue = originalValue;
             _newValue = newValue;
         }
 

--- a/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
@@ -56,7 +56,7 @@ namespace Gemini.Modules.Inspector.Inspectors
             }
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (_boundPropertyDescriptor != null)
                 _boundPropertyDescriptor.ValueChanged -= OnValueChanged;

--- a/src/Gemini.Modules.Inspector/Inspectors/RangeEditorView.xaml
+++ b/src/Gemini.Modules.Inspector/Inspectors/RangeEditorView.xaml
@@ -3,15 +3,18 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:controls="clr-namespace:Gemini.Framework.Controls;assembly=Gemini"
+             xmlns:cal="http://www.caliburnproject.org"
              mc:Ignorable="d" d:DesignWidth="300">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="50" />
         </Grid.ColumnDefinitions>
-        <Slider Grid.Column="0" Value="{Binding Value}"
+        <controls:SliderEx Grid.Column="0" Value="{Binding Value}"
 				Minimum="{Binding Minimum}"
-				Maximum="{Binding Maximum}" />
+				Maximum="{Binding Maximum}"
+                cal:Message.Attach="[Event ThumbDragStarted] = [Action DragStarted]; [Event ThumbDragCompleted] = [Action DragCompleted]" />
         <TextBox Grid.Column="1" Text="{Binding Value, StringFormat='{}{0:G7}'}" />
     </Grid>
 </UserControl>

--- a/src/Gemini.Modules.Inspector/Inspectors/RangeEditorViewModel.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/RangeEditorViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Gemini.Modules.Inspector.Inspectors
 {
-    public class RangeEditorViewModel<T> : EditorBase<T>, ILabelledInspector
+    public class RangeEditorViewModel<T> : SelectiveUndoEditorBase<T>, ILabelledInspector
     {
         private readonly T _minimum;
         private readonly T _maximum;
@@ -19,6 +19,16 @@
         {
             _minimum = minimum;
             _maximum = maximum;
+        }
+
+        public void DragStarted()
+        {
+            OnBeginEdit();
+        }
+
+        public void DragCompleted()
+        {
+            OnEndEdit();
         }
     }
 }

--- a/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+using Caliburn.Micro;
+
+using Gemini.Framework.Services;
+
+namespace Gemini.Modules.Inspector.Inspectors
+{
+    /// <summary>
+    /// This class is used for values that should only be updated after the
+    /// user has finished editing them. The view needs to call OnBeginEdit when
+    /// the user has started editing to capture the current value and call
+    /// OnEndEdit to commit the old and new value to the undo / redo manager.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the value</typeparam>
+    public abstract class SelectiveUndoEditorBase<TValue> : EditorBase<TValue>, IDisposable
+    {
+        private bool _undoEnabled = true;
+
+        public override TValue Value
+        {
+            get { return (TValue)BoundPropertyDescriptor.Value; }
+            set {
+                if (_undoEnabled)
+                {
+                    IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
+                        new ChangeObjectValueAction(BoundPropertyDescriptor, value));
+                }
+                else
+                {
+                    BoundPropertyDescriptor.Value = value;
+                }
+
+                NotifyOfPropertyChange(() => Value);
+            }
+        }
+
+        private object _originalValue = null;
+
+        protected void OnBeginEdit()
+        {
+            _undoEnabled = false;
+            _originalValue = Value;
+        }
+
+        protected void OnEndEdit()
+        {
+            if (_originalValue == null)
+                return;
+
+            try
+            {
+                var value = Value;
+                if (!_originalValue.Equals(value))
+                    IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
+                        new ChangeObjectValueAction(BoundPropertyDescriptor, _originalValue, value));
+            }
+            finally
+            {
+                _originalValue = null;
+                _undoEnabled = true;
+            }
+        }
+
+        public override void Dispose()
+        {
+            OnEndEdit();
+            base.Dispose();
+        }
+    }
+}

--- a/src/Gemini/Framework/Controls/SliderEx.cs
+++ b/src/Gemini/Framework/Controls/SliderEx.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace Gemini.Framework.Controls
+{
+    /// <summary>
+    /// Slider that exposes the thumb drag started / completed events directly
+    /// to allow Caliburn Micro to attach to the messages.
+    /// </summary>
+    public class SliderEx : Slider
+    {
+        [Category("Behavior")]
+        public event DragStartedEventHandler ThumbDragStarted;
+
+        [Category("Behavior")]
+        public event DragCompletedEventHandler ThumbDragCompleted;
+
+        protected override void OnThumbDragStarted(DragStartedEventArgs e)
+        {
+            if (ThumbDragStarted != null)
+                ThumbDragStarted(this, e);
+
+            base.OnThumbDragStarted(e);
+        }
+
+        protected override void OnThumbDragCompleted(DragCompletedEventArgs e)
+        {
+            if (ThumbDragCompleted != null)
+                ThumbDragCompleted(this, e);
+
+            base.OnThumbDragCompleted(e);
+        }
+    }
+}

--- a/src/Gemini/Gemini.csproj
+++ b/src/Gemini/Gemini.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Framework\Controls\HwndMouse.cs" />
     <Compile Include="Framework\Controls\HwndMouseEventArgs.cs" />
     <Compile Include="Framework\Controls\HwndMouseState.cs" />
+    <Compile Include="Framework\Controls\SliderEx.cs" />
     <Compile Include="Framework\Converters.cs" />
     <Compile Include="Framework\IExecutableItem.cs" />
     <Compile Include="Framework\ILayoutItem.cs" />


### PR DESCRIPTION
This makes the RangeEditor use the SelectiveUndoEditorBase to disable the
undo functionality while the user is dragging the slider, preventing
excessive ammounts of undo entries being created.

Signed-off-by: Axel Gembe <axel@gembe.net>