### PR TITLE
Themes: Add merged dictionary for all controls

### DIFF
--- a/src/Gemini/Gemini.csproj
+++ b/src/Gemini/Gemini.csproj
@@ -367,6 +367,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Themes\VS2013\Controls\Merged.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Themes\VS2013\LightTheme.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/Gemini/Themes/VS2013/BlueTheme.xaml
+++ b/src/Gemini/Themes/VS2013/BlueTheme.xaml
@@ -1,11 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Controls/Window.xaml" />
-        <ResourceDictionary Source="Controls/WindowCommands.xaml" />
-        <ResourceDictionary Source="Controls/Menu.xaml" />
-        <ResourceDictionary Source="Controls/Toolbar.xaml" />
-        <ResourceDictionary Source="Controls/Tooltip.xaml" />
+        <ResourceDictionary Source="Controls/Merged.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <!-- Menu -->

--- a/src/Gemini/Themes/VS2013/Controls/Merged.xaml
+++ b/src/Gemini/Themes/VS2013/Controls/Merged.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Menu.xaml" />
+        <ResourceDictionary Source="Toolbar.xaml" />
+        <ResourceDictionary Source="Tooltip.xaml" />
+        <ResourceDictionary Source="Window.xaml" />
+        <ResourceDictionary Source="WindowCommands.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>

--- a/src/Gemini/Themes/VS2013/DarkTheme.xaml
+++ b/src/Gemini/Themes/VS2013/DarkTheme.xaml
@@ -1,11 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Controls/Window.xaml" />
-        <ResourceDictionary Source="Controls/WindowCommands.xaml" />
-        <ResourceDictionary Source="Controls/Menu.xaml" />
-        <ResourceDictionary Source="Controls/Toolbar.xaml" />
-        <ResourceDictionary Source="Controls/Tooltip.xaml" />
+        <ResourceDictionary Source="Controls/Merged.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <!-- Menu -->

--- a/src/Gemini/Themes/VS2013/LightTheme.xaml
+++ b/src/Gemini/Themes/VS2013/LightTheme.xaml
@@ -1,11 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Controls/Window.xaml" />
-        <ResourceDictionary Source="Controls/WindowCommands.xaml" />
-        <ResourceDictionary Source="Controls/Menu.xaml" />
-        <ResourceDictionary Source="Controls/Toolbar.xaml" />
-        <ResourceDictionary Source="Controls/Tooltip.xaml" />
+        <ResourceDictionary Source="Controls/Merged.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <!-- Menu -->


### PR DESCRIPTION
Will be useful later when adding more control styles (soon)
It is also useful when you want to merge all the Gemini control styles
into an external theme.

Signed-off-by: Axel Gembe <axel@gembe.net>