### PR TITLE
Inspector: Add undo toggle to EditorBase

### DIFF
--- a/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
@@ -9,6 +9,17 @@ namespace Gemini.Modules.Inspector.Inspectors
     {
         private BoundPropertyDescriptor _boundPropertyDescriptor;
 
+        public EditorBase()
+        {
+            IsUndoEnabled = true;
+        }
+
+        public bool IsUndoEnabled
+        {
+            get;
+            set;
+        }
+
         public bool CanReset
         {
             get
@@ -93,8 +104,16 @@ namespace Gemini.Modules.Inspector.Inspectors
                 if (Equals(Value, value))
                     return;
 
-                IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
-                    new ChangeObjectValueAction(BoundPropertyDescriptor, value));
+                if (IsUndoEnabled)
+                {
+                    IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
+                        new ChangeObjectValueAction(BoundPropertyDescriptor, value));
+                }
+                else
+                {
+                    BoundPropertyDescriptor.Value = value;
+                }
+
                 NotifyOfPropertyChange(() => Value);
             }
         }

--- a/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
@@ -15,34 +15,11 @@ namespace Gemini.Modules.Inspector.Inspectors
     /// <typeparam name="TValue">Type of the value</typeparam>
     public abstract class SelectiveUndoEditorBase<TValue> : EditorBase<TValue>, IDisposable
     {
-        private bool _undoEnabled = true;
-
-        public override TValue Value
-        {
-            get { return (TValue)BoundPropertyDescriptor.Value; }
-            set {
-                if (Equals(Value, value))
-                    return;
-
-                if (_undoEnabled)
-                {
-                    IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
-                        new ChangeObjectValueAction(BoundPropertyDescriptor, value));
-                }
-                else
-                {
-                    BoundPropertyDescriptor.Value = value;
-                }
-
-                NotifyOfPropertyChange(() => Value);
-            }
-        }
-
         private object _originalValue = null;
 
         protected void OnBeginEdit()
         {
-            _undoEnabled = false;
+            IsUndoEnabled = false;
             _originalValue = Value;
         }
 
@@ -61,7 +38,7 @@ namespace Gemini.Modules.Inspector.Inspectors
             finally
             {
                 _originalValue = null;
-                _undoEnabled = true;
+                IsUndoEnabled = true;
             }
         }
 


### PR DESCRIPTION
This means that it can be removed from SelectiveUndoEditorBase and that
editors that do not need undo can just disable it in their constructor.
This closes PR #178

Signed-off-by: Axel Gembe <axel@gembe.net>