### PR TITLE
Inspector: Disable reset button when value is not dirty

### DIFF
--- a/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
@@ -9,6 +9,17 @@ namespace Gemini.Modules.Inspector.Inspectors
     {
         private BoundPropertyDescriptor _boundPropertyDescriptor;
 
+        public EditorBase()
+        {
+            IsUndoEnabled = true;
+        }
+
+        public bool IsUndoEnabled
+        {
+            get;
+            set;
+        }
+
         public bool CanReset
         {
             get
@@ -93,8 +104,16 @@ namespace Gemini.Modules.Inspector.Inspectors
                 if (Equals(Value, value))
                     return;
 
-                IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
-                    new ChangeObjectValueAction(BoundPropertyDescriptor, value));
+                if (IsUndoEnabled)
+                {
+                    IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
+                        new ChangeObjectValueAction(BoundPropertyDescriptor, value));
+                }
+                else
+                {
+                    BoundPropertyDescriptor.Value = value;
+                }
+
                 NotifyOfPropertyChange(() => Value);
             }
         }

--- a/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 using System.Windows.Data;
 using Caliburn.Micro;
 using Gemini.Framework.Services;
@@ -93,9 +94,23 @@ namespace Gemini.Modules.Inspector.Inspectors
             get { return BoundPropertyDescriptor.PropertyDescriptor.IsReadOnly; }
         }
 
+        public bool IsDirty
+        {
+            get
+            {
+                DefaultValueAttribute defaultAttribute = BoundPropertyDescriptor.PropertyDescriptor.Attributes.OfType<DefaultValueAttribute>().FirstOrDefault();
+                if (defaultAttribute == null)
+                    /* Maybe not dirty, but we have no way to know if we don't have a default value */
+                    return true;
+
+                return !Equals(defaultAttribute.Value, Value);
+            }
+        }
+
         private void OnValueChanged()
         {
             NotifyOfPropertyChange(() => Value);
+            NotifyOfPropertyChange(() => IsDirty);
         }
 
         private void OnValueChanged(object sender, EventArgs e)

--- a/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
@@ -15,34 +15,11 @@ namespace Gemini.Modules.Inspector.Inspectors
     /// <typeparam name="TValue">Type of the value</typeparam>
     public abstract class SelectiveUndoEditorBase<TValue> : EditorBase<TValue>, IDisposable
     {
-        private bool _undoEnabled = true;
-
-        public override TValue Value
-        {
-            get { return (TValue)BoundPropertyDescriptor.Value; }
-            set {
-                if (Equals(Value, value))
-                    return;
-
-                if (_undoEnabled)
-                {
-                    IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
-                        new ChangeObjectValueAction(BoundPropertyDescriptor, value));
-                }
-                else
-                {
-                    BoundPropertyDescriptor.Value = value;
-                }
-
-                NotifyOfPropertyChange(() => Value);
-            }
-        }
-
         private object _originalValue = null;
 
         protected void OnBeginEdit()
         {
-            _undoEnabled = false;
+            IsUndoEnabled = false;
             _originalValue = Value;
         }
 
@@ -61,7 +38,7 @@ namespace Gemini.Modules.Inspector.Inspectors
             finally
             {
                 _originalValue = null;
-                _undoEnabled = true;
+                IsUndoEnabled = true;
             }
         }
 

--- a/src/Gemini.Modules.Inspector/Resources/Resources.xaml
+++ b/src/Gemini.Modules.Inspector/Resources/Resources.xaml
@@ -7,6 +7,14 @@
     <xctk:InverseBoolConverter x:Key="InverseBoolConverter" />
     <xcad:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
 
+    <Style x:Key="ResetButton" TargetType="Button" BasedOn="{StaticResource {x:Static ToolBar.ButtonStyleKey}}">
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.5" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <controls:InspectorItemTemplateSelector x:Key="InspectorItemTemplateSelector">
         <controls:InspectorItemTemplateSelector.LabelledTemplate>
             <DataTemplate>
@@ -29,7 +37,8 @@
                     </Border>
                     <Button Grid.Column="3" Margin="5,0,0,0" Content="⟲" ToolTip="Reset"
                             Foreground="{DynamicResource EnvironmentToolWindowText}"
-                            Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                            Style="{StaticResource ResetButton}"
+                            IsEnabled="{Binding IsDirty}"
                             Visibility="{Binding CanReset, Converter={StaticResource BoolToVisibilityConverter}}"
                             cal:Message.Attach="Reset"/>
                 </Grid>


### PR DESCRIPTION
Adds an IsDirty property to EditorBase that can determine if the value is
dirty if the property descriptor has a DefaultValueAttribute, if it does
not it will always return true. The reset buttons IsEnabled property is
bound to this new property

Signed-off-by: Axel Gembe <axel@gembe.net>



Inspector: Only notify of editor property change once

The EditorBase class notified multiple times of property changes if the
bound property descriptor sent change notifications. This patch disables
notification when setting the value.

Signed-off-by: Axel Gembe <axel@gembe.net>


This needs #190 merged first.