### PR TITLE
Color picker: Fix for dual monitor primary screen to the right of secondary

### DIFF
--- a/src/Gemini.Modules.Inspector/Controls/ScreenColorPicker.cs
+++ b/src/Gemini.Modules.Inspector/Controls/ScreenColorPicker.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
+using Gemini.Modules.Inspector.Util;
 using Gemini.Modules.Inspector.Win32;
 using Color = System.Windows.Media.Color;
 
@@ -68,7 +69,7 @@ namespace Gemini.Modules.Inspector.Controls
             {
                 if (_bitmap != null)
                     _bitmap.Dispose();
-                _bitmap = NativeMethods.GetDesktop();
+                _bitmap = ScreenShotUtility.Take();
 
                 if (Focus()) // So that we get the Escape key.
                 {
@@ -96,8 +97,15 @@ namespace Gemini.Modules.Inspector.Controls
             NativeMethods.NativePoint cursorPosition;
             if (NativeMethods.GetCursorPos(out cursorPosition))
             {
-                var pixel = _bitmap.GetPixel(cursorPosition.X, cursorPosition.Y);
-                return new ColorEventArgs(Color.FromArgb(pixel.A, pixel.R, pixel.G, pixel.B));
+                cursorPosition.X -= (int) SystemParameters.VirtualScreenLeft;
+                cursorPosition.Y -= (int) SystemParameters.VirtualScreenTop;
+
+                if (cursorPosition.X > 0 && cursorPosition.X < _bitmap.Width &&
+                    cursorPosition.Y > 0 && cursorPosition.Y < _bitmap.Height)
+                {
+                    var pixel = _bitmap.GetPixel(cursorPosition.X, cursorPosition.Y);
+                    return new ColorEventArgs(Color.FromArgb(pixel.A, pixel.R, pixel.G, pixel.B));
+                }
             }
             return new ColorEventArgs(Colors.Black);
         }

--- a/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
+++ b/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
@@ -148,6 +148,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Util\ExpressionUtility.cs" />
+    <Compile Include="Util\ScreenShotUtility.cs" />
     <Compile Include="ViewModels\InspectorViewModel.cs" />
     <Compile Include="Views\InspectorView.xaml.cs">
       <DependentUpon>InspectorView.xaml</DependentUpon>

--- a/src/Gemini.Modules.Inspector/Util/ScreenShotUtility.cs
+++ b/src/Gemini.Modules.Inspector/Util/ScreenShotUtility.cs
@@ -1,0 +1,26 @@
+﻿using System.Drawing;
+using System.Drawing.Imaging;
+using System.Windows;
+
+namespace Gemini.Modules.Inspector.Util
+{
+    public class ScreenShotUtility
+    {
+        public static Bitmap Take()
+        {
+            int screenX = (int) SystemParameters.VirtualScreenWidth;
+            int screenY = (int) SystemParameters.VirtualScreenHeight;
+
+            var ret = new Bitmap(screenX, screenY, PixelFormat.Format32bppRgb);
+
+            using (var graphics = Graphics.FromImage(ret))
+            {
+                graphics.CopyFromScreen((int) SystemParameters.VirtualScreenLeft, (int) SystemParameters.VirtualScreenTop, 0, 0,
+                    new System.Drawing.Size((int) SystemParameters.VirtualScreenWidth, (int) SystemParameters.VirtualScreenHeight),
+                    CopyPixelOperation.SourceCopy);
+            }
+
+            return ret;
+        }
+    }
+}

--- a/src/Gemini.Modules.Inspector/Win32/NativeMethods.cs
+++ b/src/Gemini.Modules.Inspector/Win32/NativeMethods.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Windows;
 
 namespace Gemini.Modules.Inspector.Win32
 {
@@ -15,67 +16,5 @@ namespace Gemini.Modules.Inspector.Win32
 
         [DllImport("user32.dll", EntryPoint = "GetCursorPos")]
         public static extern bool GetCursorPos(out NativePoint point);
-
-        [DllImport("gdi32.dll", EntryPoint = "DeleteDC")]
-        public static extern IntPtr DeleteDC(IntPtr hdc);
-
-        [DllImport("gdi32.dll", EntryPoint = "DeleteObject")]
-        public static extern IntPtr DeleteObject(IntPtr hObject);
-
-        [DllImport("gdi32.dll", EntryPoint = "BitBlt")]
-        public static extern bool BitBlt(IntPtr hdcDest, int nXDest,
-            int nYDest, int nWidth, int nHeight, IntPtr hdcSrc,
-            int nXSrc, int nYSrc, int dwRop);
-
-        [DllImport("gdi32.dll", EntryPoint = "CreateCompatibleBitmap")]
-        public static extern IntPtr CreateCompatibleBitmap(IntPtr hdc,
-            int nWidth, int nHeight);
-
-        [DllImport("gdi32.dll", EntryPoint = "CreateCompatibleDC")]
-        public static extern IntPtr CreateCompatibleDC(IntPtr hdc);
-
-        [DllImport("gdi32.dll", EntryPoint = "SelectObject")]
-        public static extern IntPtr SelectObject(IntPtr hdc, IntPtr hgdiobjBmp);
-
-        [DllImport("user32.dll", EntryPoint = "GetDesktopWindow")]
-        public static extern IntPtr GetDesktopWindow();
-
-        [DllImport("user32.dll", EntryPoint = "GetDC")]
-        public static extern IntPtr GetDC(IntPtr hWnd);
-
-        [DllImport("user32.dll", EntryPoint = "GetSystemMetrics")]
-        public static extern int GetSystemMetrics(int nIndex);
-
-        [DllImport("user32.dll", EntryPoint = "ReleaseDC")]
-        public static extern IntPtr ReleaseDC(IntPtr hWnd, IntPtr hDC);
-
-        public static Bitmap GetDesktop()
-        {
-            IntPtr hdcScreen = GetDC(GetDesktopWindow());
-            IntPtr hdcCompatible = CreateCompatibleDC(hdcScreen);
-
-            int screenX = GetSystemMetrics(0);
-            int screenY = GetSystemMetrics(1);
-            IntPtr hBmp = CreateCompatibleBitmap(hdcScreen, screenX, screenY);
-
-            if (hBmp != IntPtr.Zero)
-            {
-                IntPtr hOldBmp = SelectObject(hdcCompatible, hBmp);
-                BitBlt(hdcCompatible, 0, 0, screenX, screenY, hdcScreen, 0, 0, 13369376);
-
-                SelectObject(hdcCompatible, hOldBmp);
-                DeleteDC(hdcCompatible);
-                ReleaseDC(GetDesktopWindow(), hdcScreen);
-
-                Bitmap bmp = Image.FromHbitmap(hBmp);
-
-                DeleteObject(hBmp);
-                GC.Collect();
-
-                return bmp;
-            }
-
-            return null;
-        }
     }
 }


### PR DESCRIPTION
This would cause the mouse coordinates to get negative, thereby crashing
on trying to read the pixel value from the bitmap.

Signed-off-by: Axel Gembe <axel@gembe.net>