### PR TITLE
Theme: Add margin to command shortcut text to prevent overlap

### DIFF
--- a/src/Gemini/Themes/VS2013/Controls/Menu.xaml
+++ b/src/Gemini/Themes/VS2013/Controls/Menu.xaml
@@ -172,6 +172,7 @@
                 </Border>
                 <TextBlock x:Name="InputGestureText" Grid.Column="2" 
                            Padding="0 2 2 2"
+                           Margin="6 0 0 0"
                            VerticalAlignment="Center"
                            Text="{TemplateBinding InputGestureText}" 
                            DockPanel.Dock="Right" />
@@ -226,6 +227,7 @@
                                       RecognizesAccessKey="True" />
                 </Border>
                 <TextBlock x:Name="InputGestureText" Grid.Column="2" 
+                           Margin="6 0 0 0"
                            Padding="0 2 2 2"
                            VerticalAlignment="Center"
                            Text="{TemplateBinding InputGestureText}" 


### PR DESCRIPTION
Based on change suggestion in #184