### PR TITLE
Allow for optional DLL generation

### DIFF
--- a/src/Gemini.Modules.CodeCompiler/CodeCompiler.cs
+++ b/src/Gemini.Modules.CodeCompiler/CodeCompiler.cs
@@ -55,14 +55,14 @@ namespace Gemini.Modules.CodeCompiler
                 
                 if (exportDll)
                 {
-                    if (exportPath == null)
+                    if (exportDir == null)
                     {
-                        exportPath = typeof(Gemini.AppBootstrapper).Assembly.Location;
+                        exportDir = typeof(Gemini.AppBootstrapper).Assembly.Location;
                     }
                     if (!outputName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                         outputName += ".dll";
                     _output.AppendLine("------ Exporting to DLL");
-                    var dllPath = System.IO.Path.Combine(exportPath, outputName);
+                    var dllPath = System.IO.Path.Combine(exportDir, outputName);
                     try
                     {
                         if (File.Exists(dllPath))

--- a/src/Gemini.Modules.CodeCompiler/CodeCompiler.cs
+++ b/src/Gemini.Modules.CodeCompiler/CodeCompiler.cs
@@ -30,7 +30,7 @@ namespace Gemini.Modules.CodeCompiler
             _errorList = errorList;
         }
 
-        public Assembly Compile(IEnumerable<SyntaxTree> syntaxTrees, IEnumerable<MetadataReference> references, string outputName)
+        public Assembly Compile(IEnumerable<SyntaxTree> syntaxTrees, IEnumerable<MetadataReference> references, string outputName, bool exportDll = false, string exportPath = null)
         {
             _output.AppendLine("------ Compile started");
 
@@ -52,6 +52,31 @@ namespace Gemini.Modules.CodeCompiler
                 }
                 _output.AppendLine("------ Compile finished");
                 ms.Seek(0, SeekOrigin.Begin);
+                
+                if (exportDll)
+                {
+                    if (exportPath == null)
+                    {
+                        exportPath = typeof(Gemini.AppBootstrapper).Assembly.Location;
+                    }
+                    if (!outputName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                        outputName += ".dll";
+                    _output.AppendLine("------ Exporting to DLL");
+                    var dllPath = System.IO.Path.Combine(exportPath, outputName);
+                    try
+                    {
+                        if (File.Exists(dllPath))
+                            File.Delete(dllPath);
+                        ms.WriteTo(new FileStream(dllPath, FileMode.Create));
+                        _output.AppendLine("------ Export finished");
+                        _output.AppendLine("-> " + dllPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        _output.AppendLine("------ Export failed");
+                        _output.AppendLine(ex.Message);
+                    }
+                }
                 return Assembly.Load(ms.ToArray());
             }
         }

--- a/src/Gemini.Modules.CodeCompiler/CodeCompiler.cs
+++ b/src/Gemini.Modules.CodeCompiler/CodeCompiler.cs
@@ -30,7 +30,7 @@ namespace Gemini.Modules.CodeCompiler
             _errorList = errorList;
         }
 
-        public Assembly Compile(IEnumerable<SyntaxTree> syntaxTrees, IEnumerable<MetadataReference> references, string outputName, bool exportDll = false, string exportPath = null)
+        public Assembly Compile(IEnumerable<SyntaxTree> syntaxTrees, IEnumerable<MetadataReference> references, string outputName, bool exportDll = false, string exportDir = null)
         {
             _output.AppendLine("------ Compile started");
 

--- a/src/Gemini.Modules.CodeCompiler/ICodeCompiler.cs
+++ b/src/Gemini.Modules.CodeCompiler/ICodeCompiler.cs
@@ -9,6 +9,8 @@ namespace Gemini.Modules.CodeCompiler
         Assembly Compile(
             IEnumerable<SyntaxTree> syntaxTrees,
             IEnumerable<MetadataReference> references,
-            string outputName);
+            string outputName,
+            bool exportDll = false,
+            string exportDir = null);
     }
 }

--- a/src/Gemini/Modules/ToolBars/IToolBars.cs
+++ b/src/Gemini/Modules/ToolBars/IToolBars.cs
@@ -6,5 +6,6 @@ namespace Gemini.Modules.ToolBars
     {
         IObservableCollection<IToolBar> Items {get;}
         bool Visible { get; set; }
+        bool Locked { get; set; }
     }
 }

--- a/src/Gemini/Modules/ToolBars/ViewModels/ToolBarsViewModel.cs
+++ b/src/Gemini/Modules/ToolBars/ViewModels/ToolBarsViewModel.cs
@@ -26,12 +26,24 @@ namespace Gemini.Modules.ToolBars.ViewModels
                 NotifyOfPropertyChange();
             }
         }
+        
+        private bool _locked;
+        public bool Locked
+        {
+            get { return _locked; }
+            set
+            {
+                _locked = value;
+                NotifyOfPropertyChange();
+            }
+        }
 
         [ImportingConstructor]
         public ToolBarsViewModel(IToolBarBuilder toolBarBuilder)
         {
             _toolBarBuilder = toolBarBuilder;
             _items = new BindableCollection<IToolBar>();
+            _locked = false;
         }
 
         protected override void OnViewLoaded(object view)

--- a/src/Gemini/Modules/ToolBars/Views/ToolBarsView.xaml
+++ b/src/Gemini/Modules/ToolBars/Views/ToolBarsView.xaml
@@ -12,6 +12,7 @@
     </UserControl.Resources>
     <controls:ToolBarTrayContainer>
         <ToolBarTray x:Name="ToolBarTray"
-				     Visibility="{Binding Visible, Converter={StaticResource BoolToVisibilityConverter}}" />
+				     Visibility="{Binding Visible, Converter={StaticResource BoolToVisibilityConverter}}"
+				     IsLocked={Binding Locked}/>
     </controls:ToolBarTrayContainer>
 </UserControl>


### PR DESCRIPTION
- Added optional parameters for DLL generation/export
- Added writing of the MemoryStream to a DLL in the specified directory or current execution directory should no path be specified.
- Added a Locked property that can be set via Shell.Toolbars.Locked which when set to true, will disable moving of the toolbars. This should fix #170 .
