### PR TITLE
Undo Redo: Improve performance when undo / redo stack changes

### DIFF
--- a/src/Gemini/Framework/Document.cs
+++ b/src/Gemini/Framework/Document.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -67,7 +67,7 @@ namespace Gemini.Framework
 
 	    void ICommandHandler<UndoCommandDefinition>.Update(Command command)
 	    {
-            command.Enabled = UndoRedoManager.UndoStack.Any();
+            command.Enabled = UndoRedoManager.CanUndo;
 	    }
 
 	    Task ICommandHandler<UndoCommandDefinition>.Run(Command command)
@@ -78,7 +78,7 @@ namespace Gemini.Framework
 
         void ICommandHandler<RedoCommandDefinition>.Update(Command command)
         {
-            command.Enabled = UndoRedoManager.RedoStack.Any();
+            command.Enabled = UndoRedoManager.CanRedo;
         }
 
         Task ICommandHandler<RedoCommandDefinition>.Run(Command command)

--- a/src/Gemini/Modules/UndoRedo/Design/DesignTimeHistoryViewModel.cs
+++ b/src/Gemini/Modules/UndoRedo/Design/DesignTimeHistoryViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Gemini.Modules.UndoRedo.ViewModels;
+using Gemini.Modules.UndoRedo.ViewModels;
 
 namespace Gemini.Modules.UndoRedo.Design
 {
@@ -7,10 +7,10 @@ namespace Gemini.Modules.UndoRedo.Design
         public DesignTimeHistoryViewModel()
             : base(null)
         {
-            HistoryItems.Add(new HistoryItemViewModel("Initial", HistoryItemType.InitialState));
-            HistoryItems.Add(new HistoryItemViewModel("Foo", HistoryItemType.Undo));
-            HistoryItems.Add(new HistoryItemViewModel("Bar", HistoryItemType.Current));
-            HistoryItems.Add(new HistoryItemViewModel("Baz", HistoryItemType.Redo));
+            HistoryItems.Add(new HistoryItemViewModel("Initial") { ItemType = HistoryItemType.InitialState });
+            HistoryItems.Add(new HistoryItemViewModel("Foo") { ItemType = HistoryItemType.Undo });
+            HistoryItems.Add(new HistoryItemViewModel("Bar") { ItemType = HistoryItemType.Current });
+            HistoryItems.Add(new HistoryItemViewModel("Baz") { ItemType = HistoryItemType.Redo });
         }
     }
 }

--- a/src/Gemini/Modules/UndoRedo/IUndoRedoManager.cs
+++ b/src/Gemini/Modules/UndoRedo/IUndoRedoManager.cs
@@ -1,12 +1,15 @@
-﻿using System;
+using System;
+using System.ComponentModel;
 using Caliburn.Micro;
 
 namespace Gemini.Modules.UndoRedo
 {
-    public interface IUndoRedoManager
+    public interface IUndoRedoManager : INotifyPropertyChanged
     {
-        IObservableCollection<IUndoableAction> UndoStack { get; }
-        IObservableCollection<IUndoableAction> RedoStack { get; }
+        IObservableCollection<IUndoableAction> ActionStack { get; }
+        IUndoableAction CurrentAction { get; }
+        int UndoActionCount { get; }
+        int RedoActionCount { get; }
 
         event EventHandler BatchBegin;
         event EventHandler BatchEnd;
@@ -15,10 +18,12 @@ namespace Gemini.Modules.UndoRedo
 
         void ExecuteAction(IUndoableAction action);
 
+        bool CanUndo { get; }
         void Undo(int actionCount);
         void UndoTo(IUndoableAction action);
         void UndoAll();
 
+        bool CanRedo { get; }
         void Redo(int actionCount);
         void RedoTo(IUndoableAction action);
     }

--- a/src/Gemini/Modules/UndoRedo/ViewModels/HistoryItemViewModel.cs
+++ b/src/Gemini/Modules/UndoRedo/ViewModels/HistoryItemViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Caliburn.Micro;
+using Caliburn.Micro;
 
 namespace Gemini.Modules.UndoRedo.ViewModels
 {
@@ -17,22 +17,28 @@ namespace Gemini.Modules.UndoRedo.ViewModels
             get { return _name ?? _action.Name; }
         }
 
-        private readonly HistoryItemType _itemType;
+        private HistoryItemType _itemType;
         public HistoryItemType ItemType
         {
             get { return _itemType; }
+            set {
+                if (_itemType == value)
+                    return;
+
+                _itemType = value;
+
+                NotifyOfPropertyChange(() => ItemType);
+            }
         }
 
-        public HistoryItemViewModel(IUndoableAction action, HistoryItemType itemType)
+        public HistoryItemViewModel(IUndoableAction action)
         {
             _action = action;
-            _itemType = itemType;
         }
 
-        public HistoryItemViewModel(string name, HistoryItemType itemType)
+        public HistoryItemViewModel(string name)
         {
             _name = name;
-            _itemType = itemType;
         }
     }
 }

--- a/src/Gemini/Modules/UndoRedo/Views/HistoryView.xaml.cs
+++ b/src/Gemini/Modules/UndoRedo/Views/HistoryView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Gemini.Modules.UndoRedo.ViewModels;
@@ -19,7 +19,7 @@ namespace Gemini.Modules.UndoRedo.Views
         {
             var viewModel = (HistoryViewModel) DataContext;
             var itemViewModel = (HistoryItemViewModel) ((FrameworkElement) sender).DataContext;
-            viewModel.UndoOrRedoTo(itemViewModel);
+            viewModel.UndoOrRedoTo(itemViewModel, true);
         }
     }
 }


### PR DESCRIPTION
I noticed while profiling my code that 99% of the CPU time to change the
undo redo stack is spent in Gemini instead of actually setting values.

This commit changes the undo / redo stack into a single stack with an
integer keeping track of what is undo and what is redo. This way we can
just easily synchronize the HistoryViewModel from the CollectionChanged
event of the UndoRedoManager stack. The advantage is that we can use an
item index in HistoryViewModel that is derived from the UndoRedoManager's
item index.

To do an undo / redo, we only need do undo / execute the needed actions
and update the UndoActions. The HistoryViewModel listens for UndoActions
changes and will update all the HistoryItemViewModel's ItemTypes. This has
the advantage of only refreshing the view once when all the actions have
been completed.

This greatly improves performance for large undo / redo operations.