### PR TITLE
Color Picker: Disable undo redo while dialog is open

### DIFF
--- a/src/Gemini.Modules.Inspector/Inspectors/ColorEditorView.xaml
+++ b/src/Gemini.Modules.Inspector/Inspectors/ColorEditorView.xaml
@@ -6,6 +6,7 @@
              xmlns:xctk="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit"
              xmlns:p="clr-namespace:Gemini.Modules.Inspector.Properties"
              xmlns:l="http://gu.se/Localization"
+             xmlns:cal="http://www.caliburnproject.org"
              xmlns:local="clr-namespace:Gemini.Modules.Inspector.Controls"
              l:ErrorHandling.Mode="ReturnErrorInfoPreserveNeutral"
              mc:Ignorable="d">
@@ -19,6 +20,7 @@
                           RecentColorsHeader="{l:Static p:Resources.ColorEditorRecentColors}"
                           AvailableColorsHeader="{l:Static p:Resources.ColorEditorAvailableColors}"
                           AdvancedButtonHeader="{l:Static p:Resources.ColorEditorAdvanced}"
+                          cal:Message.Attach="[Event Closed] = [Action Closed]; [Event Opened] = [Action Opened]"
                           />
         <local:ScreenColorPicker x:Name="ScreenColorPicker" Margin="3 0 0 0"
                                  PickingStarted="OnScreenColorPickerPickingStarted"

--- a/src/Gemini.Modules.Inspector/Inspectors/ColorEditorViewModel.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/ColorEditorViewModel.cs
@@ -2,7 +2,7 @@
 
 namespace Gemini.Modules.Inspector.Inspectors
 {
-    public class ColorEditorViewModel : EditorBase<Color>, ILabelledInspector
+    public class ColorEditorViewModel : SelectiveUndoEditorBase<Color>, ILabelledInspector
     {
         private bool _usingAlphaChannel = true;
 
@@ -19,6 +19,16 @@ namespace Gemini.Modules.Inspector.Inspectors
 
                 NotifyOfPropertyChange(() => UsingAlphaChannel);
             }
+        }
+
+        public void Opened()
+        {
+            OnBeginEdit();
+        }
+
+        public void Closed()
+        {
+            OnEndEdit();
         }
     }
 }


### PR DESCRIPTION
This prevents excessive undo redo entries while the user is editing the
color. The undo redo stack is updated as soon as the user closes the color
picker.

Signed-off-by: Axel Gembe <axel@gembe.net>
