### PR TITLE
Inspector: Fix selective undo editor with type converters

### DIFF
--- a/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
@@ -133,10 +133,10 @@ namespace Gemini.Modules.Inspector.Inspectors
                     if (Converter == null)
                         throw new InvalidCastException("editor property value does not match editor type and no converter specified");
 
-                    return (TValue) Converter.Convert(BoundPropertyDescriptor.Value, typeof(TValue), null, CultureInfo.CurrentCulture);
+                    return (TValue) Converter.Convert(RawValue, typeof(TValue), null, CultureInfo.CurrentCulture);
                 }
 
-                return (TValue) BoundPropertyDescriptor.Value;
+                return (TValue) RawValue;
             }
 
             set
@@ -165,7 +165,7 @@ namespace Gemini.Modules.Inspector.Inspectors
                     }
                     else
                     {
-                        BoundPropertyDescriptor.Value = newValue;
+                        RawValue = newValue;
                     }
                 }
                 finally
@@ -175,6 +175,12 @@ namespace Gemini.Modules.Inspector.Inspectors
 
                 OnValueChanged();
             }
+        }
+
+        protected object RawValue
+        {
+            get { return BoundPropertyDescriptor.Value; }
+            set { BoundPropertyDescriptor.Value = value; }
         }
 
         public virtual void Dispose()

--- a/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
@@ -20,7 +20,7 @@ namespace Gemini.Modules.Inspector.Inspectors
         protected void OnBeginEdit()
         {
             IsUndoEnabled = false;
-            _originalValue = Value;
+            _originalValue = RawValue;
         }
 
         protected void OnEndEdit()
@@ -30,7 +30,7 @@ namespace Gemini.Modules.Inspector.Inspectors
 
             try
             {
-                var value = Value;
+                var value = RawValue;
                 if (!_originalValue.Equals(value))
                     IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
                         new ChangeObjectValueAction(BoundPropertyDescriptor, _originalValue, value));


### PR DESCRIPTION
The selective undo editor would create an undo entry that would set the
wrong type for the bound property descriptor.

Signed-off-by: Axel Gembe <axel@gembe.net>