### PR TITLE
Inspector: Add string converter for history items

### DIFF
--- a/src/Gemini.Modules.Inspector/Inspectors/ChangeObjectValueAction.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/ChangeObjectValueAction.cs
@@ -1,5 +1,7 @@
 ﻿using Gemini.Modules.Inspector.Properties;
 using Gemini.Modules.UndoRedo;
+using System.Globalization;
+using System.Windows.Data;
 
 namespace Gemini.Modules.Inspector.Inspectors
 {
@@ -8,27 +10,43 @@ namespace Gemini.Modules.Inspector.Inspectors
         private readonly BoundPropertyDescriptor _boundPropertyDescriptor;
         private readonly object _originalValue;
         private readonly object _newValue;
+        private readonly IValueConverter _stringConverter;
 
         public string Name
         {
             get
             {
+                string origText;
+                string newText;
+
+                if (_stringConverter != null)
+                {
+                    origText = (string) _stringConverter.Convert(_originalValue, typeof(string), null, CultureInfo.CurrentUICulture);
+                    newText = (string) _stringConverter.Convert(_newValue, typeof(string), null, CultureInfo.CurrentUICulture);
+                }
+                else
+                {
+                    origText = _originalValue.ToString();
+                    newText = _newValue.ToString();
+                }
+
                 return string.Format(Resources.ChangeObjectValueActionFormat,
                     _boundPropertyDescriptor.PropertyDescriptor.DisplayName,
-                    _originalValue,
-                    _newValue);
+                    origText,
+                    newText);
             }
         }
 
-        public ChangeObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, object newValue) :
-            this(boundPropertyDescriptor, boundPropertyDescriptor.Value, newValue)
+        public ChangeObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, object newValue, IValueConverter stringConverter) :
+            this(boundPropertyDescriptor, boundPropertyDescriptor.Value, newValue, stringConverter)
         { }
 
-        public ChangeObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, object originalValue, object newValue)
+        public ChangeObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, object originalValue, object newValue, IValueConverter stringConverter)
         {
             _boundPropertyDescriptor = boundPropertyDescriptor;
             _originalValue = originalValue;
             _newValue = newValue;
+            _stringConverter = stringConverter;
         }
 
         public void Execute()

--- a/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
@@ -11,9 +11,11 @@ namespace Gemini.Modules.Inspector.Inspectors
     public abstract class EditorBase<TValue> : InspectorBase, IEditor, IDisposable
     {
         private BoundPropertyDescriptor _boundPropertyDescriptor;
+        private IShell _shell;
 
         public EditorBase()
         {
+            _shell = IoC.Get<IShell>();
             IsUndoEnabled = true;
         }
 
@@ -158,9 +160,10 @@ namespace Gemini.Modules.Inspector.Inspectors
 
                 try
                 {
-                    if (IsUndoEnabled)
+                    var item = _shell.ActiveItem;
+                    if (IsUndoEnabled && item != null)
                     {
-                        IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
+                        item.UndoRedoManager.ExecuteAction(
                             new ChangeObjectValueAction(BoundPropertyDescriptor, newValue));
                     }
                     else

--- a/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
@@ -63,6 +63,12 @@ namespace Gemini.Modules.Inspector.Inspectors
             set;
         }
 
+        public IValueConverter StringConverter
+        {
+            get;
+            set;
+        }
+
         private void CleanupPropertyChanged()
         {
             if (_boundPropertyDescriptor != null) {
@@ -164,7 +170,7 @@ namespace Gemini.Modules.Inspector.Inspectors
                     if (IsUndoEnabled && item != null)
                     {
                         item.UndoRedoManager.ExecuteAction(
-                            new ChangeObjectValueAction(BoundPropertyDescriptor, newValue));
+                            new ChangeObjectValueAction(BoundPropertyDescriptor, newValue, StringConverter));
                     }
                     else
                     {

--- a/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/SelectiveUndoEditorBase.cs
@@ -33,7 +33,7 @@ namespace Gemini.Modules.Inspector.Inspectors
                 var value = Value;
                 if (!_originalValue.Equals(value))
                     IoC.Get<IShell>().ActiveItem.UndoRedoManager.ExecuteAction(
-                        new ChangeObjectValueAction(BoundPropertyDescriptor, _originalValue, value));
+                        new ChangeObjectValueAction(BoundPropertyDescriptor, _originalValue, value, StringConverter));
             }
             finally
             {


### PR DESCRIPTION
This can be used to format history items more nicely.

Signed-off-by: Axel Gembe <axel@gembe.net>
