### PR TITLE
Shell: Fix duplicate ActiveDocumentChanged

### DIFF
--- a/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
+++ b/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
@@ -185,21 +185,32 @@ namespace Gemini.Modules.Shell.ViewModels
 			DeactivateItem(document, true);
 		}
 
+        private bool _activateItemGuard = false;
+
         public override void ActivateItem(IDocument item)
         {
-            if (_closing)
+            if (_closing || _activateItemGuard)
                 return;
 
-            if (ReferenceEquals(item, ActiveItem))
-                return;
+            _activateItemGuard = true;
 
-            RaiseActiveDocumentChanging();
+            try
+            {
+                if (ReferenceEquals(item, ActiveItem))
+                    return;
 
-            var currentActiveItem = ActiveItem;
+                RaiseActiveDocumentChanging();
 
-            base.ActivateItem(item);
+                var currentActiveItem = ActiveItem;
 
-            RaiseActiveDocumentChanged();
+                base.ActivateItem(item);
+
+                RaiseActiveDocumentChanged();
+            }
+            finally
+            {
+                _activateItemGuard = false;
+            }
         }
 
 	    private void RaiseActiveDocumentChanging()


### PR DESCRIPTION
The shell calls ActivateItem inside the ActiveLayoutItem setter which
causes ActiveDocumentChanged to be raised twice because ActivateItem calls
base.ActivateItem(item) which sets ActiveLayoutItem which calls
ActivateItem where the ReferenceEquals check fails to detect the duplicate
activation because ActiveItem is not updated yet.

This patch adds a guard in ActivateItem that prevents recursive calls.

Signed-off-by: Axel Gembe <axel@gembe.net>