### PR TITLE
Inspector: Add reset object action to undo redo manager

### DIFF
--- a/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
+++ b/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Inspectors\BitmapSourceEditorView.xaml.cs">
       <DependentUpon>BitmapSourceEditorView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Inspectors\ResetObjectValueAction.cs" />
     <Compile Include="Inspectors\ChangeObjectValueAction.cs" />
     <Compile Include="Inspectors\CheckBoxEditorView.xaml.cs">
       <DependentUpon>CheckBoxEditorView.xaml</DependentUpon>

--- a/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/EditorBase.cs
@@ -39,7 +39,18 @@ namespace Gemini.Modules.Inspector.Inspectors
         public void Reset()
         {
             if (CanReset)
-                BoundPropertyDescriptor.PropertyDescriptor.ResetValue(BoundPropertyDescriptor.PropertyOwner);
+            {
+                var item = _shell.ActiveItem;
+                if (IsUndoEnabled && item != null)
+                {
+                    item.UndoRedoManager.ExecuteAction(
+                        new ResetObjectValueAction(BoundPropertyDescriptor, StringConverter));
+                }
+                else
+                {
+                    BoundPropertyDescriptor.PropertyDescriptor.ResetValue(BoundPropertyDescriptor.PropertyOwner);
+                }
+            }
         }
 
         public override string Name

--- a/src/Gemini.Modules.Inspector/Inspectors/ResetObjectValueAction.cs
+++ b/src/Gemini.Modules.Inspector/Inspectors/ResetObjectValueAction.cs
@@ -1,0 +1,62 @@
+﻿using Gemini.Modules.Inspector.Properties;
+using Gemini.Modules.UndoRedo;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Gemini.Modules.Inspector.Inspectors
+{
+    public class ResetObjectValueAction : IUndoableAction
+    {
+        private readonly BoundPropertyDescriptor _boundPropertyDescriptor;
+        private readonly object _originalValue;
+        private object _newValue;
+        private readonly IValueConverter _stringConverter;
+
+        public string Name
+        {
+            get
+            {
+                string origText;
+                string newText;
+
+                if (_stringConverter != null)
+                {
+                    origText = (string) _stringConverter.Convert(_originalValue, typeof(string), null, CultureInfo.CurrentUICulture);
+                    newText = (string) _stringConverter.Convert(_newValue, typeof(string), null, CultureInfo.CurrentUICulture);
+                }
+                else
+                {
+                    origText = _originalValue.ToString();
+                    newText = _newValue.ToString();
+                }
+
+                return string.Format(Resources.ResetObjectValueActionFormat,
+                    _boundPropertyDescriptor.PropertyDescriptor.DisplayName,
+                    origText,
+                    newText);
+            }
+        }
+
+        public ResetObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, IValueConverter stringConverter) :
+            this(boundPropertyDescriptor, boundPropertyDescriptor.Value, stringConverter)
+        { }
+
+        public ResetObjectValueAction(BoundPropertyDescriptor boundPropertyDescriptor, object originalValue, IValueConverter stringConverter)
+        {
+            _boundPropertyDescriptor = boundPropertyDescriptor;
+            _originalValue = originalValue;
+            _stringConverter = stringConverter;
+        }
+
+        public void Execute()
+        {
+            _boundPropertyDescriptor.PropertyDescriptor.ResetValue(_boundPropertyDescriptor.PropertyOwner);
+            _newValue = _boundPropertyDescriptor.Value;
+        }
+
+        public void Undo()
+        {
+            _boundPropertyDescriptor.Value = _originalValue;
+        }
+    }
+}

--- a/src/Gemini.Modules.Inspector/Properties/Resources.Designer.cs
+++ b/src/Gemini.Modules.Inspector/Properties/Resources.Designer.cs
@@ -142,6 +142,15 @@ namespace Gemini.Modules.Inspector.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reset {0} from {1} to {2}.
+        /// </summary>
+        internal static string ResetObjectValueActionFormat {
+            get {
+                return ResourceManager.GetString("ResetObjectValueActionFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ⟲.
         /// </summary>
         internal static string ResetSymbol {

--- a/src/Gemini.Modules.Inspector/Properties/Resources.de.resx
+++ b/src/Gemini.Modules.Inspector/Properties/Resources.de.resx
@@ -156,4 +156,7 @@
   <data name="ColorEditorRecentColors" xml:space="preserve">
     <value>Letzte Farben</value>
   </data>
+  <data name="ResetObjectValueActionFormat" xml:space="preserve">
+    <value>{0} von {1} zu {2} rücksetzen</value>
+  </data>
 </root>

--- a/src/Gemini.Modules.Inspector/Properties/Resources.resx
+++ b/src/Gemini.Modules.Inspector/Properties/Resources.resx
@@ -156,4 +156,7 @@
   <data name="ColorEditorAdvanced" xml:space="preserve">
     <value>Advanced</value>
   </data>
+  <data name="ResetObjectValueActionFormat" xml:space="preserve">
+    <value>Reset {0} from {1} to {2}</value>
+  </data>
 </root>


### PR DESCRIPTION
This creates a new ResetObjectValueAction that gets pushed to the undo
redo stack when the reset button of a value in the inspector gets pressed.

Signed-off-by: Axel Gembe <axel@gembe.net>