### PR TITLE
Undo Redo: Add optional limit for number of undo entries

### DIFF
--- a/src/Gemini/Modules/UndoRedo/IUndoRedoManager.cs
+++ b/src/Gemini/Modules/UndoRedo/IUndoRedoManager.cs
@@ -11,6 +11,8 @@ namespace Gemini.Modules.UndoRedo
         event EventHandler BatchBegin;
         event EventHandler BatchEnd;
 
+        int? UndoCountLimit { get; set; }
+
         void ExecuteAction(IUndoableAction action);
 
         void Undo(int actionCount);


### PR DESCRIPTION
This patch adds the UndoCountLimit property to the UndoRedoManager which
is used to limit the maximum length of the stack. By default it is set to
-1 which means that no limit is enforced. Any value below 0 is used to
disable the limit. If the value is above zero, the undo stack is always
limited to this length but the redo stack is not limited by this as it
should not get longer than the undo stack anyway as long as the limit is
not changed.

Signed-off-by: Axel Gembe <axel@gembe.net>