### PR TITLE
LayoutItemStatePersister Stream Dispose clean-up

### DIFF
--- a/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
+++ b/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
@@ -15,16 +15,10 @@ namespace Gemini.Modules.Shell.Services
     {
         public bool SaveState(IShell shell, IShellView shellView, string fileName)
         {
-            FileStream stream = null;
-
             try
             {
-                stream = new FileStream(fileName, FileMode.Create, FileAccess.Write);
-
-                using (var writer = new BinaryWriter(stream))
+                using (var writer = new BinaryWriter(new FileStream(fileName, FileMode.Create, FileAccess.Write)))
                 {
-                    stream = null;
-
                     IEnumerable<ILayoutItem> itemStates = shell.Documents.Concat(shell.Tools.Cast<ILayoutItem>());
 
                     int itemCount = 0;
@@ -121,13 +115,6 @@ namespace Gemini.Modules.Shell.Services
             {
                 return false;
             }
-            finally
-            {
-                if (stream != null)
-                {
-                    stream.Dispose();
-                }
-            }
 
             return true;
         }
@@ -156,16 +143,10 @@ namespace Gemini.Modules.Shell.Services
                 return false;
             }
 
-            FileStream stream = null;
-
             try
             {
-                stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
-
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new BinaryReader(new FileStream(fileName, FileMode.Open, FileAccess.Read)))
                 {
-                    stream = null;
-
                     int count = reader.ReadInt32();
 
                     for (int i = 0; i < count; i++)
@@ -211,12 +192,6 @@ namespace Gemini.Modules.Shell.Services
             catch
             {
                 return false;
-            }
-            finally
-            {
-                if (stream != null) {
-                    stream.Close();
-                }
             }
 
             return true;

--- a/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
+++ b/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
@@ -129,7 +129,7 @@ namespace Gemini.Modules.Shell.Services
                 return null;
 
             var type = Type.GetType(typeName);
-            if (type == null || !typeof(ILayoutItem).IsInstanceOfType(type))
+            if (type == null || !typeof(ILayoutItem).IsAssignableFrom(type))
                 return null;
             return type;
         }


### PR DESCRIPTION
If a stream is wrapped in a **BinaryWriter** or **BinaryReader** and '_leaveOpen_' is false (as it is by default) they will take care of closing/disposing the underlying stream. Those finally blocks are futile.

Also if the constructor of **FileStream** throws an exception, the variable 'stream' will remain null, so again: the finally blocks are futile...

I added a small bugfix too in _GetTypeFromContractNameAsILayoutItem()_. I am pretty sure **Type**._IsInstanceOf()_ does not take another Type as an argument. I think you meant something like: 'does this type implement _ILayoutItem_?'