### PR TITLE
Truncate-middle converter

### DIFF
--- a/src/Gemini/Framework/Document.cs
+++ b/src/Gemini/Framework/Document.cs
@@ -64,8 +64,8 @@ namespace Gemini.Framework
                 return _toolBar;
             }
         }
-
-	    void ICommandHandler<UndoCommandDefinition>.Update(Command command)
+        
+        void ICommandHandler<UndoCommandDefinition>.Update(Command command)
 	    {
             command.Enabled = UndoRedoManager.CanUndo;
 	    }

--- a/src/Gemini/Framework/LayoutItemBase.cs
+++ b/src/Gemini/Framework/LayoutItemBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.IO;
 using System.Windows.Input;
@@ -29,6 +29,19 @@ namespace Gemini.Framework
 		{
 			get { return null; }
 		}
+
+        private string _toolTip = string.Empty;
+
+        [Browsable(false)]
+        public string ToolTip
+        {
+            get { return _toolTip; }
+            set
+            {
+                _toolTip = value;
+                NotifyOfPropertyChange(() => ToolTip);
+            }
+        }
 
 		private bool _isSelected;
 

--- a/src/Gemini/Framework/PersistedDocument.cs
+++ b/src/Gemini/Framework/PersistedDocument.cs
@@ -10,7 +10,18 @@ namespace Gemini.Framework
 
         public bool IsNew { get; private set; }
         public string FileName { get; private set; }
-        public string FilePath { get; private set; }
+
+        private string _filePath = null;
+        public string FilePath
+        {
+            get { return _filePath; }
+            private set
+            {
+                _filePath = value;
+                NotifyOfPropertyChange(() => FilePath);
+                UpdateToolTip();
+            }
+        }
 
         public bool IsDirty
         {
@@ -35,6 +46,11 @@ namespace Gemini.Framework
         private void UpdateDisplayName()
         {
             DisplayName = IsDirty ? FileName + "*" : FileName;
+        }
+
+        private void UpdateToolTip()
+        {
+            ToolTip = FilePath;
         }
 
         public async Task New(string fileName)

--- a/src/Gemini/Modules/Shell/Converters/TruncateMiddleConverter.cs
+++ b/src/Gemini/Modules/Shell/Converters/TruncateMiddleConverter.cs
@@ -17,13 +17,13 @@ namespace Gemini.Modules.Shell.Converters
 
             string result = value.ToString();
             int frontLength = 15;
-            int backLength = 16;
+            int backLength = result.EndsWith("*") ? 17 : 16;
 
             var lengths = parameter as int[];
             if (lengths != null && lengths.Length == 2)
             {
                 frontLength = lengths[0];
-                backLength = lengths[1];
+                backLength = result.EndsWith("*") ? lengths[1] + 1 : lengths[1];
             }
 
             if (result.Length > frontLength + 3 + backLength)

--- a/src/Gemini/Modules/Shell/Converters/TruncateMiddleConverter.cs
+++ b/src/Gemini/Modules/Shell/Converters/TruncateMiddleConverter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Gemini.Modules.Shell.Converters
+{
+    /// <summary>
+    /// Converter to truncate middle of long string. It can be helpful if information at the end is important.
+    /// </summary>
+    public class TruncateMiddleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return DependencyProperty.UnsetValue;
+
+            string result = value.ToString();
+            int frontLength = 15;
+            int backLength = 16;
+
+            var lengths = parameter as int[];
+            if (lengths != null && lengths.Length == 2)
+            {
+                frontLength = lengths[0];
+                backLength = lengths[1];
+            }
+
+            if (result.Length > frontLength + 3 + backLength)
+            {
+                result = result.Substring(0, frontLength).Trim() + "..." + result.Substring(result.Length - backLength).Trim();
+            }
+
+            return result;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Gemini/Modules/Shell/Views/ShellView.xaml
+++ b/src/Gemini/Modules/Shell/Views/ShellView.xaml
@@ -88,6 +88,7 @@
 							<Setter Property="CloseCommand" Value="{Binding Model.CloseCommand}" />
 							<Setter Property="IconSource" Value="{Binding Model.IconSource, Converter={StaticResource NullableValueConverter}}" />
                             <Setter Property="IsSelected" Value="{Binding Model.IsSelected, Mode=TwoWay}" />
+                            <Setter Property="ToolTip" Value="{Binding Model.ToolTip, Mode=OneWay}" />
                         </Style>
 					</controls:PanesStyleSelector.DocumentStyle>
 					<controls:PanesStyleSelector.ToolStyle>

--- a/src/Gemini/Modules/Shell/Views/ShellView.xaml
+++ b/src/Gemini/Modules/Shell/Views/ShellView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Gemini.Modules.Shell.Views.ShellView"
+<UserControl x:Class="Gemini.Modules.Shell.Views.ShellView"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
 			 xmlns:controls="clr-namespace:Gemini.Modules.Shell.Controls"
@@ -13,6 +13,7 @@
 	<UserControl.Resources>
 		<ResourceDictionary>
 			<converters:NullableValueConverter x:Key="NullableValueConverter" />
+            <converters:TruncateMiddleConverter x:Key="TruncateMiddleConverter" />
 			<xcad:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
             <DataTemplate x:Key="IconTitleTemplate" DataType="{x:Type xcad:LayoutContent}">
                 <Grid VerticalAlignment="Center">
@@ -82,8 +83,8 @@
 				<controls:PanesStyleSelector>
 					<controls:PanesStyleSelector.DocumentStyle>
 						<Style TargetType="{x:Type xcad:LayoutItem}">
-						<Setter Property="ContentId" Value="{Binding Model.ContentId}" />
-							<Setter Property="Title" Value="{Binding Model.DisplayName, Mode=OneWay}" />
+						    <Setter Property="ContentId" Value="{Binding Model.ContentId}" />
+                            <Setter Property="Title" Value="{Binding Model.DisplayName, Mode=OneWay, Converter={StaticResource TruncateMiddleConverter}}" />
 							<Setter Property="CloseCommand" Value="{Binding Model.CloseCommand}" />
 							<Setter Property="IconSource" Value="{Binding Model.IconSource, Converter={StaticResource NullableValueConverter}}" />
                             <Setter Property="IsSelected" Value="{Binding Model.IsSelected, Mode=TwoWay}" />

--- a/src/Gemini/Themes/VS2013/Controls/Tooltip.xaml
+++ b/src/Gemini/Themes/VS2013/Controls/Tooltip.xaml
@@ -1,5 +1,6 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
     
     <Style x:Key="{x:Type ToolTip}" TargetType="ToolTip">
         <Setter Property="OverridesDefaultStyle" Value="true" />
@@ -30,5 +31,14 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <!-- Hide ToopTip that has an empty content -->
+        <Style.Triggers>
+            <Trigger Property="Content" Value="{x:Static sys:String.Empty}">
+                <Setter Property="Visibility" Value="Collapsed"/>
+            </Trigger>
+            <Trigger Property="Content" Value="{x:Null}">
+                <Setter Property="Visibility" Value="Collapsed"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
Documents which titles are longer than the Window width are annoying. This simple PO sets a length limit on the display name of the document in the way VS does, i,.e. "abcdef...xyz.ext".