### PR TITLE
Fix reset button being attached to the group object in groups

### DIFF
--- a/src/Gemini.Modules.Inspector/Resources/Resources.xaml
+++ b/src/Gemini.Modules.Inspector/Resources/Resources.xaml
@@ -37,6 +37,7 @@
                             BorderBrush="Transparent"
                             IsEnabled="{Binding IsDirty}"
                             Visibility="{Binding CanReset, Converter={StaticResource BoolToVisibilityConverter}}"
+                            cal:Action.TargetWithoutContext="{Binding}"
                             cal:Message.Attach="Reset"/>
                 </Grid>
             </DataTemplate>


### PR DESCRIPTION
The reset button only worked for objects that are not in a collapsible
group. When an object was in a group clicking the reset button resulted
in invoking the Reset method on the group instead of the object.

The solution seems to be to refresh the Action.TargetWithoutContext to
the current binding.