### PR TITLE
Upgrade to Metro 1.6.5

### DIFF
--- a/src/Gemini/Gemini.csproj
+++ b/src/Gemini/Gemini.csproj
@@ -43,6 +43,9 @@
       <HintPath>..\packages\Caliburn.Micro.2.0.2\lib\net45\Caliburn.Micro.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net45\ControlzEx.dll</HintPath>
+    </Reference>
     <Reference Include="Gu.Localization, Version=6.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Gu.Localization.6.1.0.0\lib\net45\Gu.Localization.dll</HintPath>
       <Private>True</Private>
@@ -51,9 +54,8 @@
       <HintPath>..\packages\Gu.Wpf.Localization.6.1.0.0\lib\net45\Gu.Wpf.Localization.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MahApps.Metro, Version=1.2.4.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\MahApps.Metro.1.2.4.0\lib\net45\MahApps.Metro.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MahApps.Metro, Version=1.6.5.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MahApps.Metro.1.6.5\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -62,8 +64,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\MahApps.Metro.1.2.4.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Gemini/packages.config
+++ b/src/Gemini/packages.config
@@ -2,9 +2,10 @@
 <packages>
   <package id="Caliburn.Micro" version="2.0.2" targetFramework="net45" />
   <package id="Caliburn.Micro.Core" version="2.0.2" targetFramework="net45" />
+  <package id="ControlzEx" version="3.0.2.4" targetFramework="net45" />
   <package id="Extended.Wpf.Toolkit" version="2.9" targetFramework="net45" />
   <package id="Gu.Localization" version="6.1.0.0" targetFramework="net45" />
   <package id="Gu.Wpf.Localization" version="6.1.0.0" targetFramework="net45" />
-  <package id="MahApps.Metro" version="1.2.4.0" targetFramework="net45" />
+  <package id="MahApps.Metro" version="1.6.5" targetFramework="net45" />
   <package id="Xceed.Wpf.AvalonDock.Themes.VS2013" version="2.9.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Our main software has a dependency on Metro (which we upgraded to 1.6.5), however a standalone editor we have also depends on Metro and Gemini, so we upgraded Metro to the Metro 1.6.5, seems to work without any side effects. - Brian

(Greetings Tim! This above comment is about the Verbs Editor, we just discovered it didn't work anymore because of our upgrade to Metro as mentioned above -Brian)