### PR TITLE
make the connection items selectable in the Gemini.Modules.GraphEditor

### DIFF
--- a/src/Gemini.Demo/Modules/FilterDesigner/ViewModels/ConnectionViewModel.cs
+++ b/src/Gemini.Demo/Modules/FilterDesigner/ViewModels/ConnectionViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.ComponentModel;
 using System.Windows;
 using Caliburn.Micro;
 
@@ -6,7 +7,20 @@ namespace Gemini.Demo.Modules.FilterDesigner.ViewModels
 {
     public class ConnectionViewModel : PropertyChangedBase
     {
+        private bool _isSelected;
+        [Browsable(false)]
+        public bool IsSelected
+        {
+            get { return _isSelected; }
+            set
+            {
+                _isSelected = value;
+                NotifyOfPropertyChange(() => IsSelected);
+            }
+        }
+
         private OutputConnectorViewModel _from;
+        [Browsable(false)]
         public OutputConnectorViewModel From
         {
             get { return _from; }
@@ -32,6 +46,7 @@ namespace Gemini.Demo.Modules.FilterDesigner.ViewModels
         }
 
         private InputConnectorViewModel _to;
+        [Browsable(false)]
         public InputConnectorViewModel To
         {
             get { return _to; }
@@ -57,6 +72,7 @@ namespace Gemini.Demo.Modules.FilterDesigner.ViewModels
         }
 
         private Point _fromPosition;
+        [Browsable(false)]
         public Point FromPosition
         {
             get { return _fromPosition; }
@@ -68,6 +84,7 @@ namespace Gemini.Demo.Modules.FilterDesigner.ViewModels
         }
 
         private Point _toPosition;
+        [Browsable(false)]
         public Point ToPosition
         {
             get { return _toPosition; }

--- a/src/Gemini.Demo/Modules/FilterDesigner/ViewModels/GraphViewModel.cs
+++ b/src/Gemini.Demo/Modules/FilterDesigner/ViewModels/GraphViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Windows;
@@ -35,7 +35,12 @@ namespace Gemini.Demo.Modules.FilterDesigner.ViewModels
         {
             get { return _elements.Where(x => x.IsSelected); }
         }
-          
+
+        public IEnumerable<ConnectionViewModel> SelectedConnections
+        {
+            get { return _connections.Where(x => x.IsSelected); }
+        }
+
         [ImportingConstructor]
         public GraphViewModel(IInspectorTool inspectorTool)
         {
@@ -131,20 +136,29 @@ namespace Gemini.Demo.Modules.FilterDesigner.ViewModels
             Elements.Remove(element);
         }
 
-        public void DeleteSelectedElements()
+        public void DeleteSelectedObjects()
         {
             Elements.Where(x => x.IsSelected)
                 .ToList()
                 .ForEach(DeleteElement);
+            var selectedConnections = SelectedConnections
+                .Where(x => x.IsSelected)
+                .ToList();
+            Connections.RemoveRange(selectedConnections);
         }
 
         public void OnSelectionChanged()
         {
             var selectedElements = SelectedElements.ToList();
+            var selectedConnections = SelectedConnections.ToList();
 
             if (selectedElements.Count == 1)
                 _inspectorTool.SelectedObject = new InspectableObjectBuilder()
                     .WithObjectProperties(selectedElements[0], x => true)
+                    .ToInspectableObject();
+            else if (selectedConnections.Count == 1)
+                _inspectorTool.SelectedObject = new InspectableObjectBuilder()
+                    .WithObjectProperties(selectedConnections[0], x => true)
                     .ToInspectableObject();
             else
                 _inspectorTool.SelectedObject = null;

--- a/src/Gemini.Demo/Modules/FilterDesigner/Views/GraphView.xaml
+++ b/src/Gemini.Demo/Modules/FilterDesigner/Views/GraphView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Gemini.Demo.Modules.FilterDesigner.Views.GraphView"
+<UserControl x:Class="Gemini.Demo.Modules.FilterDesigner.Views.GraphView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -24,6 +24,7 @@
 									PreviewMouseMove="OnGraphControlMouseMove"
 									PreviewMouseWheel="OnGraphControlMouseWheel"
 									SelectionChanged="OnGraphControlSelectionChanged"
+                                    ConnectionSelectionChanged="OnGraphControlSelectionChanged"
 									ConnectionDragStarted="OnGraphControlConnectionDragStarted"
 									ConnectionDragging="OnGraphControlConnectionDragging"
 									ConnectionDragCompleted="OnGraphControlConnectionDragCompleted"
@@ -37,8 +38,13 @@
 							<Setter Property="IsSelected" Value="{Binding IsSelected}" />
 						</Style>
 					</local:GraphControl.ElementItemContainerStyle>
-			
-					<local:GraphControl.ElementItemTemplate>
+                    <local:GraphControl.ConnectionItemContainerStyle>
+                        <Style TargetType="{x:Type local:ConnectionItem}">
+                            <Setter Property="IsSelected" Value="{Binding IsSelected}" />
+                        </Style>
+                    </local:GraphControl.ConnectionItemContainerStyle>
+
+                    <local:GraphControl.ElementItemTemplate>
 						<DataTemplate DataType="vm:ElementViewModel">
 							<DataTemplate.Resources>
 								<Style TargetType="local:ConnectorItem">
@@ -117,10 +123,15 @@
 			
 					<local:GraphControl.ConnectionItemTemplate>
 						<DataTemplate DataType="vm:ConnectionViewModel">
-							<local:BezierLine Stroke="LightSkyBlue" StrokeThickness="1"
-									X1="{Binding FromPosition.X}" Y1="{Binding FromPosition.Y}"
-									X2="{Binding ToPosition.X}" Y2="{Binding ToPosition.Y}" />
-						</DataTemplate>
+							<local:BezierLine x:Name="ConnectionLine" Stroke="LightSkyBlue" StrokeThickness="1"
+                                              X1="{Binding FromPosition.X}" Y1="{Binding FromPosition.Y}"
+                                              X2="{Binding ToPosition.X}" Y2="{Binding ToPosition.Y}" />
+                            <DataTemplate.Triggers>
+                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                    <Setter TargetName="ConnectionLine" Property="Stroke" Value="Yellow" />
+                                </DataTrigger>
+                            </DataTemplate.Triggers>
+                        </DataTemplate>
 					</local:GraphControl.ConnectionItemTemplate>
 				</local:GraphControl>
 			</local:ZoomAndPanControl>

--- a/src/Gemini.Demo/Modules/FilterDesigner/Views/GraphView.xaml.cs
+++ b/src/Gemini.Demo/Modules/FilterDesigner/Views/GraphView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -35,7 +35,7 @@ namespace Gemini.Demo.Modules.FilterDesigner.Views
         protected override void OnKeyDown(KeyEventArgs e)
         {
             if (e.Key == Key.Delete)
-                ((GraphViewModel) DataContext).DeleteSelectedElements();
+                ((GraphViewModel) DataContext).DeleteSelectedObjects();
             base.OnKeyDown(e);
         }
 

--- a/src/Gemini.Modules.GraphEditor/Controls/ConnectionItem.cs
+++ b/src/Gemini.Modules.GraphEditor/Controls/ConnectionItem.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using Gemini.Framework;
+
+namespace Gemini.Modules.GraphEditor.Controls
+{
+    public class ConnectionItem : ListBoxItem
+    {
+        static ConnectionItem()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(ConnectionItem),
+                new FrameworkPropertyMetadata(typeof(ConnectionItem)));
+        }
+
+        private GraphControl ParentGraphControl
+        {
+            get { return VisualTreeUtility.FindParent<GraphControl>(this); }
+        }
+
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            ParentGraphControl.UnselectAll();
+            base.OnMouseLeftButtonDown(e);
+        }
+    }
+}

--- a/src/Gemini.Modules.GraphEditor/Controls/ConnectionItemsControl.cs
+++ b/src/Gemini.Modules.GraphEditor/Controls/ConnectionItemsControl.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+
+namespace Gemini.Modules.GraphEditor.Controls
+{
+    public class ConnectionItemsControl : ListBox
+    {
+        public ConnectionItemsControl()
+        {
+            SelectionMode = SelectionMode.Extended;
+        }
+
+        protected override DependencyObject GetContainerForItemOverride()
+        {
+            return new ConnectionItem();
+            
+        }
+
+        protected override bool IsItemItsOwnContainerOverride(object item)
+        {
+            return item is ConnectionItem;
+        }
+    }
+}

--- a/src/Gemini.Modules.GraphEditor/Controls/ElementItem.cs
+++ b/src/Gemini.Modules.GraphEditor/Controls/ElementItem.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Gemini.Framework;
@@ -85,7 +85,7 @@ namespace Gemini.Modules.GraphEditor.Controls
             if (parentGraphControl == null)
                 return;
 
-            parentGraphControl.SelectedElements.Clear();
+            parentGraphControl.UnselectAll();
             IsSelected = true;
         }
 

--- a/src/Gemini.Modules.GraphEditor/Controls/GraphControl.cs
+++ b/src/Gemini.Modules.GraphEditor/Controls/GraphControl.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -12,6 +12,7 @@ namespace Gemini.Modules.GraphEditor.Controls
     public class GraphControl : Control
     {
         private ElementItemsControl _elementItemsControl;
+        private ConnectionItemsControl _connectionItemsControl;
 
         static GraphControl()
         {
@@ -130,10 +131,27 @@ namespace Gemini.Modules.GraphEditor.Controls
         #endregion
 
         public event SelectionChangedEventHandler SelectionChanged;
-
+        public event SelectionChangedEventHandler ConnectionSelectionChanged;
         public IList SelectedElements
         {
             get { return _elementItemsControl.SelectedItems; }
+        }
+
+        public IList SelectedConnections
+        {
+            get { return _connectionItemsControl.SelectedItems; }
+        }
+
+        public void SelectAll()
+        {
+            _elementItemsControl.SelectAll();
+            _connectionItemsControl.SelectAll();
+        }
+
+        public void UnselectAll()
+        {
+            _elementItemsControl.UnselectAll();
+            _connectionItemsControl.UnselectAll();
         }
 
         public GraphControl()
@@ -147,7 +165,14 @@ namespace Gemini.Modules.GraphEditor.Controls
         {
             _elementItemsControl = (ElementItemsControl) Template.FindName("PART_ElementItemsControl", this);
             _elementItemsControl.SelectionChanged += OnElementItemsControlSelectChanged;
+            _connectionItemsControl = ((ConnectionItemsControl) Template.FindName("PART_ConnectionItemsControl", this));
+            _connectionItemsControl.SelectionChanged += OnConnectionsControlSelectionChanged;
             base.OnApplyTemplate();
+        }
+
+        private void OnConnectionsControlSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ConnectionSelectionChanged?.Invoke(this, e);
         }
 
         private void OnElementItemsControlSelectChanged(object sender, SelectionChangedEventArgs e)
@@ -160,6 +185,7 @@ namespace Gemini.Modules.GraphEditor.Controls
         protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
         {
             _elementItemsControl.SelectedItems.Clear();
+            _connectionItemsControl.SelectedItems.Clear();
             base.OnMouseLeftButtonDown(e);
         }
 

--- a/src/Gemini.Modules.GraphEditor/Themes/Generic.xaml
+++ b/src/Gemini.Modules.GraphEditor/Themes/Generic.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:Gemini.Modules.GraphEditor.Controls">
@@ -15,6 +15,15 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+    <Style TargetType="local:ConnectionItem">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:ConnectionItem">
+                    <ContentPresenter />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
 	<Style TargetType="local:GraphControl">
 		<Setter Property="Template">
@@ -39,16 +48,17 @@
 								</VisualBrush>
 							</Border.Background>
 							<Grid>
-								<ItemsControl ItemsSource="{TemplateBinding ConnectionsSource}"
+                                <local:ConnectionItemsControl x:Name="PART_ConnectionItemsControl"
+                                              ItemsSource="{TemplateBinding ConnectionsSource}"
 											  ItemContainerStyle="{TemplateBinding ConnectionItemContainerStyle}"
 											  ItemTemplate="{TemplateBinding ConnectionItemTemplate}"
                                               ItemTemplateSelector="{TemplateBinding ConnectionItemDataTemplateSelector}">
-									<ItemsControl.ItemsPanel>
-										<ItemsPanelTemplate>
-											<Canvas />
-										</ItemsPanelTemplate>
-									</ItemsControl.ItemsPanel>
-								</ItemsControl>
+                                    <ListBox.Template>
+                                        <ControlTemplate TargetType="ListBox">
+                                            <Canvas IsItemsHost="True" />
+                                        </ControlTemplate>
+                                    </ListBox.Template>
+								</local:ConnectionItemsControl>
 							
 								<local:ElementItemsControl x:Name="PART_ElementItemsControl"
 														   ItemsSource="{TemplateBinding ElementsSource}"


### PR DESCRIPTION
In some designers implementation the action of select a connection is a frequently requested requirement.
- ConnectionItemsControl : ListBox control added
- ConnectionItem : ListBoxItem control added
- Event ConnectionSelectionChanged in the GraphControl added
- SelectedConnections property in the GraphControl added
- Designer Gemini.Demo updated