### PR TITLE
Fix VS2013 MenuItem styles

### DIFF
--- a/src/Gemini/Themes/VS2013/Controls/Menu.xaml
+++ b/src/Gemini/Themes/VS2013/Controls/Menu.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
   Originally from the Wide framework:
   https://github.com/chandramouleswaran/Wide
   
@@ -362,9 +362,15 @@
 
     <!--Set default styles-->
     <Style TargetType="Separator" BasedOn="{StaticResource MetroSeparator}" />
-    <Style TargetType="MenuItem" BasedOn="{StaticResource MetroMenuItem}" />
+    <Style TargetType="MenuItem" BasedOn="{StaticResource MetroMenuItem}">
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
     <Style TargetType="Menu" BasedOn="{StaticResource StandardMenu}" />
     <Style TargetType="ContextMenu" BasedOn="{StaticResource MetroContextMenu}" />
     <Style TargetType="xcad:ContextMenuEx" BasedOn="{StaticResource MetroContextMenu}" />
-    <Style TargetType="xcad:MenuItemEx" BasedOn="{StaticResource MetroMenuItem}" />
+    <Style TargetType="xcad:MenuItemEx" BasedOn="{StaticResource MetroMenuItem}">
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
Based on the recommendation by @BHandle here https://github.com/tgjones/gemini/issues/291#issuecomment-443011486

Avoids WPF generating traces like:
System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.ItemsControl', AncestorLevel='1''. BindingExpression:Path=HorizontalContentAlignment; DataItem=null; target element is 'MenuItemEx' (Name=''); target property is 'HorizontalContentAlignment' (type 'HorizontalAlignment')
System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.ItemsControl', AncestorLevel='1''. BindingExpression:Path=VerticalContentAlignment; DataItem=null; target element is 'MenuItemEx' (Name=''); target property is 'VerticalContentAlignment' (type 'VerticalAlignment')

Note: VS2019 seems to have removed the UTF8 BOM header and the file is now strictly ANSI