### PR TITLE
General fix ups

### DIFF
--- a/src/Gemini.Demo/Modules/TextEditor/EditorProvider.cs
+++ b/src/Gemini.Demo/Modules/TextEditor/EditorProvider.cs
@@ -9,10 +9,10 @@ using Gemini.Demo.Properties;
 
 namespace Gemini.Demo.Modules.TextEditor
 {
-	[Export(typeof(IEditorProvider))]
-	public class EditorProvider : IEditorProvider
-	{
-		private readonly List<string> _extensions = new List<string>
+    [Export(typeof(IEditorProvider))]
+    public class EditorProvider : IEditorProvider
+    {
+        private static readonly List<string> _extensions = new List<string>
         {
             ".txt",
             ".cmd"
@@ -23,25 +23,18 @@ namespace Gemini.Demo.Modules.TextEditor
             get { yield return new EditorFileType(Resources.EditorProviderTextFile, ".txt"); }
         }
 
-		public bool Handles(string path)
-		{
-			var extension = Path.GetExtension(path);
-			return _extensions.Contains(extension);
-		}
+        public bool CanCreateNew => true;
 
-        public IDocument Create()
+        public bool Handles(string path)
         {
-            return new EditorViewModel();
+            var extension = Path.GetExtension(path);
+            return _extensions.Contains(extension);
         }
 
-        public async Task New(IDocument document, string name)
-        {
-            await ((EditorViewModel) document).New(name);
-        }
+        public IDocument Create() => new EditorViewModel();
 
-        public async Task Open(IDocument document, string path)
-		{
-			await ((EditorViewModel) document).Load(path);
-		}
-	}
+        public async Task New(IDocument document, string name) => await ((EditorViewModel)document).New(name);
+
+        public async Task Open(IDocument document, string path) => await ((EditorViewModel)document).Load(path);
+    }
 }

--- a/src/Gemini.Modules.CodeEditor/EditorProvider.cs
+++ b/src/Gemini.Modules.CodeEditor/EditorProvider.cs
@@ -11,49 +11,36 @@ using Gemini.Modules.CodeEditor.Properties;
 
 namespace Gemini.Modules.CodeEditor
 {
-	[Export(typeof(IEditorProvider))]
-	public class EditorProvider : IEditorProvider
-	{
-	    private readonly LanguageDefinitionManager _languageDefinitionManager;
+    [Export(typeof(IEditorProvider))]
+    public class EditorProvider : IEditorProvider
+    {
+        private readonly LanguageDefinitionManager _languageDefinitionManager;
 
         [ImportingConstructor]
-	    public EditorProvider(LanguageDefinitionManager languageDefinitionManager)
-	    {
-	        _languageDefinitionManager = languageDefinitionManager;
-	    }
-
-	    public IEnumerable<EditorFileType> FileTypes
-	    {
-	        get
-	        {
-	            return _languageDefinitionManager.LanguageDefinitions
-	                .Select(languageDefinition => new EditorFileType
-	                {
-	                    Name = languageDefinition.Name + Resources.EditorProviderFileSuffix,
-	                    FileExtension = languageDefinition.FileExtensions.First()
-	                });
-	        }
-	    }
-
-	    public bool Handles(string path)
-	    {
-	        var extension = Path.GetExtension(path);
-	        return extension != null && _languageDefinitionManager.GetDefinitionByExtension(extension) != null;
-	    }
-
-	    public IDocument Create()
+        public EditorProvider(LanguageDefinitionManager languageDefinitionManager)
         {
-            return IoC.Get<CodeEditorViewModel>();
+            _languageDefinitionManager = languageDefinitionManager;
         }
 
-	    public async Task New(IDocument document, string name)
+        public IEnumerable<EditorFileType> FileTypes => _languageDefinitionManager.LanguageDefinitions
+            .Select(languageDefinition => new EditorFileType
+            {
+                Name = languageDefinition.Name + Resources.EditorProviderFileSuffix,
+                FileExtension = languageDefinition.FileExtensions.First()
+            });
+
+        public bool CanCreateNew => true;
+
+        public bool Handles(string path)
         {
-            await ((CodeEditorViewModel) document).New(name);
+            var extension = Path.GetExtension(path);
+            return extension != null && _languageDefinitionManager.GetDefinitionByExtension(extension) != null;
         }
 
-	    public async Task Open(IDocument document, string path)
-        {
-            await ((CodeEditorViewModel) document).Load(path);
-        }
-	}
+        public IDocument Create() => IoC.Get<CodeEditorViewModel>();
+
+        public async Task New(IDocument document, string name) => await ((CodeEditorViewModel)document).New(name);
+
+        public async Task Open(IDocument document, string path) => await ((CodeEditorViewModel)document).Load(path);
+    }
 }

--- a/src/Gemini.sln
+++ b/src/Gemini.sln
@@ -14,9 +14,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{748FD7C1-877B-451D-809A-68E032C39B34}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		..\appveyor.yml = ..\appveyor.yml
-		..\CHANGELOG.markdown = ..\CHANGELOG.markdown
-		..\README.markdown = ..\README.markdown
+		..\CHANGELOG.md = ..\CHANGELOG.md
+		..\LICENCE.txt = ..\LICENCE.txt
+		..\README.md = ..\README.md
+		..\version.json = ..\version.json
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Modules.Inspector", "Gemini.Modules.Inspector\Gemini.Modules.Inspector.csproj", "{0F8463BD-C1B0-4F2B-855D-49B6963B3337}"

--- a/src/Gemini/Framework/Services/IEditorProvider.cs
+++ b/src/Gemini/Framework/Services/IEditorProvider.cs
@@ -4,14 +4,16 @@ using System.Threading.Tasks;
 namespace Gemini.Framework.Services
 {
     public interface IEditorProvider
-	{
+    {
         IEnumerable<EditorFileType> FileTypes { get; }
 
-		bool Handles(string path);
+        bool CanCreateNew { get; }
+
+        bool Handles(string path);
 
         IDocument Create();
 
         Task New(IDocument document, string name);
         Task Open(IDocument document, string path);
-	}
+    }
 }

--- a/src/Gemini/Framework/Tool.cs
+++ b/src/Gemini/Framework/Tool.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Caliburn.Micro;
 using Gemini.Framework.Services;
@@ -7,41 +8,32 @@ using Gemini.Modules.ToolBars.Models;
 
 namespace Gemini.Framework
 {
-	public abstract class Tool : LayoutItemBase, ITool
-	{
-		private ICommand _closeCommand;
-		public override ICommand CloseCommand
-		{
-			get { return _closeCommand ?? (_closeCommand = new RelayCommand(p => IsVisible = false, p => true)); }
-		}
+    public abstract class Tool : LayoutItemBase, ITool
+    {
+        private ICommand _closeCommand;
+        public override ICommand CloseCommand => _closeCommand ?? (_closeCommand = new AsyncCommand(() => TryCloseAsync(null)));
 
-	    public abstract PaneLocation PreferredLocation { get; }
+        public abstract PaneLocation PreferredLocation { get; }
 
-	    public virtual double PreferredWidth
-	    {
-            get { return 200; }
-	    }
+        public virtual double PreferredWidth => 200;
 
-        public virtual double PreferredHeight
+        public virtual double PreferredHeight => 200;
+
+        private bool _isVisible;
+        public bool IsVisible
         {
-            get { return 200; }
+            get => _isVisible;
+            set
+            {
+                _isVisible = value;
+                NotifyOfPropertyChange(() => IsVisible);
+            }
         }
-
-		private bool _isVisible;
-		public bool IsVisible
-		{
-			get { return _isVisible; }
-			set
-			{
-				_isVisible = value;
-				NotifyOfPropertyChange(() => IsVisible);
-			}
-		}
 
         private ToolBarDefinition _toolBarDefinition;
         public ToolBarDefinition ToolBarDefinition
         {
-            get { return _toolBarDefinition; }
+            get => _toolBarDefinition;
             protected set
             {
                 _toolBarDefinition = value;
@@ -50,7 +42,7 @@ namespace Gemini.Framework
             }
         }
 
-	    private IToolBar _toolBar;
+        private IToolBar _toolBar;
         public IToolBar ToolBar
         {
             get
@@ -68,15 +60,18 @@ namespace Gemini.Framework
             }
         }
 
-        public override bool ShouldReopenOnStart
+        // Tool windows should always reopen on app start by default.
+        public override bool ShouldReopenOnStart => true;
+
+        protected Tool()
         {
-            // Tool windows should always reopen on app start by default.
-            get { return true; }
+            IsVisible = true;
         }
 
-		protected Tool()
-		{
-			IsVisible = true;
-		}
-	}
+        public override Task TryCloseAsync(bool? dialogResult = null)
+        {
+            IsVisible = false;
+            return base.TryCloseAsync(dialogResult);
+        }
+    };
 }

--- a/src/Gemini/Modules/MainMenu/Models/CommandMenuItem.cs
+++ b/src/Gemini/Modules/MainMenu/Models/CommandMenuItem.cs
@@ -14,40 +14,19 @@ namespace Gemini.Modules.MainMenu.Models
         private readonly StandardMenuItem _parent;
         private readonly List<StandardMenuItem> _listItems;
 
-        public override string Text
-        {
-            get { return _command.Text; }
-        }
+        public override string Text => _command.Text;
 
-        public override Uri IconSource
-        {
-            get { return _command.IconSource; }
-        }
+        public override Uri IconSource => _command.IconSource;
 
-        public override string InputGestureText
-        {
-            get
-            {
-                return _keyGesture == null
-                    ? string.Empty
-                    : _keyGesture.GetDisplayStringForCulture(CultureInfo.CurrentUICulture);
-            }
-        }
+        public override string InputGestureText => _keyGesture == null
+            ? string.Empty
+            : _keyGesture.GetDisplayStringForCulture(CultureInfo.CurrentUICulture);
 
-        public override ICommand Command
-        {
-            get { return IoC.Get<ICommandService>().GetTargetableCommand(_command); }
-        }
+        public override ICommand Command => IoC.Get<ICommandService>().GetTargetableCommand(_command);
 
-        public override bool IsChecked
-        {
-            get { return _command.Checked; }
-        }
+        public override bool IsChecked => _command.Checked;
 
-        public override bool IsVisible
-        {
-            get { return _command.Visible; }
-        }
+        public override bool IsVisible => _command.Visible;
 
         private bool IsListItem { get; set; }
 
@@ -58,12 +37,11 @@ namespace Gemini.Modules.MainMenu.Models
             _parent = parent;
 
             _listItems = new List<StandardMenuItem>();
+
+            _command.PropertyChanged += CommandPropertyChanged;
         }
 
-        CommandDefinitionBase ICommandUiItem.CommandDefinition
-        {
-            get { return _command.CommandDefinition; }
-        }
+        CommandDefinitionBase ICommandUiItem.CommandDefinition => _command.CommandDefinition;
 
         void ICommandUiItem.Update(CommandHandlerWrapper commandHandler)
         {
@@ -92,5 +70,24 @@ namespace Gemini.Modules.MainMenu.Models
                 }
             }
         }
-    }
+
+        private void CommandPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(_command.Visible):
+                    NotifyOfPropertyChange(nameof(IsVisible));
+                    break;
+
+                case nameof(_command.Checked):
+                    NotifyOfPropertyChange(nameof(IsChecked));
+                    break;
+
+                case nameof(_command.Text):
+                case nameof(_command.IconSource):
+                    NotifyOfPropertyChange(e.PropertyName);
+                    break;
+            }
+        }
+    };
 }

--- a/src/Gemini/Modules/Shell/Commands/NewFileCommandHandler.cs
+++ b/src/Gemini/Modules/Shell/Commands/NewFileCommandHandler.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using Caliburn.Micro;
 using Gemini.Framework.Commands;
 using Gemini.Framework.Services;
-using Gemini.Framework.Threading;
 using Gemini.Properties;
 
 namespace Gemini.Modules.Shell.Commands
@@ -30,7 +29,12 @@ namespace Gemini.Modules.Shell.Commands
         public void Populate(Command command, List<Command> commands)
         {
             foreach (var editorProvider in _editorProviders)
+            {
+                if (!editorProvider.CanCreateNew)
+                    continue;
+
                 foreach (var editorFileType in editorProvider.FileTypes)
+                {
                     commands.Add(new Command(command.CommandDefinition)
                     {
                         Text = editorFileType.Name,
@@ -40,6 +44,8 @@ namespace Gemini.Modules.Shell.Commands
                             FileType = editorFileType
                         }
                     });
+                }
+            }
         }
 
         public async Task Run(Command command)
@@ -68,6 +74,6 @@ namespace Gemini.Modules.Shell.Commands
         {
             public IEditorProvider EditorProvider;
             public EditorFileType FileType;
-        }
-    }
+        };
+    };
 }

--- a/src/Gemini/Modules/Shell/Commands/OpenFileCommandHandler.cs
+++ b/src/Gemini/Modules/Shell/Commands/OpenFileCommandHandler.cs
@@ -23,16 +23,27 @@ namespace Gemini.Modules.Shell.Commands
             _editorProviders = editorProviders;
         }
 
+        public override void Update(Command command)
+        {
+            base.Update(command);
+
+            command.Enabled = _editorProviders != null && _editorProviders.Length > 0;
+        }
+
         public override async Task Run(Command command)
         {
             var dialog = new OpenFileDialog();
 
-            dialog.Filter = "All Supported Files|" + string.Join(";", _editorProviders
+            string filter = null;
+
+            filter = "All Supported Files|" + string.Join(";", _editorProviders
                 .SelectMany(x => x.FileTypes).Select(x => "*" + x.FileExtension));
 
-            dialog.Filter += "|" + string.Join("|", _editorProviders
+            filter += "|" + string.Join("|", _editorProviders
                 .SelectMany(x => x.FileTypes)
                 .Select(x => x.Name + "|*" + x.FileExtension));
+
+            dialog.Filter = filter;
 
             if (dialog.ShowDialog() == true)
                 await _shell.OpenDocumentAsync(await GetEditor(dialog.FileName));

--- a/src/Gemini/Modules/Shell/Views/ShellView.xaml.cs
+++ b/src/Gemini/Modules/Shell/Views/ShellView.xaml.cs
@@ -2,45 +2,47 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;
-using System.Windows.Input;
 using Gemini.Framework;
 using Gemini.Modules.Shell.ViewModels;
 
 namespace Gemini.Modules.Shell.Views
 {
-	public partial class ShellView : IShellView
-	{
-	    public ShellView()
-		{
-			InitializeComponent();
-		}
+    public partial class ShellView : IShellView
+    {
+        public ShellView()
+        {
+            InitializeComponent();
+        }
 
-	    public void LoadLayout(Stream stream, Action<ITool> addToolCallback, Action<IDocument> addDocumentCallback,
+        public void LoadLayout(Stream stream, Action<ITool> addToolCallback, Action<IDocument> addDocumentCallback,
                                Dictionary<string, ILayoutItem> itemsState)
-	    {
+        {
             LayoutUtility.LoadLayout(Manager, stream, addDocumentCallback, addToolCallback, itemsState);
-	    }
+        }
 
         public void SaveLayout(Stream stream)
         {
             LayoutUtility.SaveLayout(Manager, stream);
         }
 
-	    private void OnManagerLayoutUpdated(object sender, EventArgs e)
-	    {
-	        UpdateFloatingWindows();
-	    }
+        private void OnManagerLayoutUpdated(object sender, EventArgs e)
+        {
+            UpdateFloatingWindows();
+        }
 
-	    public void UpdateFloatingWindows()
-	    {
-	        var mainWindow = Window.GetWindow(this);
-	        var mainWindowIcon = (mainWindow != null) ? mainWindow.Icon : null;
-            var showFloatingWindowsInTaskbar = ((ShellViewModel) DataContext).ShowFloatingWindowsInTaskbar;
-	        foreach (var window in Manager.FloatingWindows)
-	        {
+        public void UpdateFloatingWindows()
+        {
+            if (DataContext == null)
+                return;
+
+            var mainWindow = Window.GetWindow(this);
+            var mainWindowIcon = (mainWindow != null) ? mainWindow.Icon : null;
+            var showFloatingWindowsInTaskbar = ((ShellViewModel)DataContext).ShowFloatingWindowsInTaskbar;
+            foreach (var window in Manager.FloatingWindows)
+            {
                 window.Icon = mainWindowIcon;
-	            window.ShowInTaskbar = showFloatingWindowsInTaskbar;
-	        }
-	    }
-	}
+                window.ShowInTaskbar = showFloatingWindowsInTaskbar;
+            }
+        }
+    };
 }


### PR DESCRIPTION
CommandMenuItem touch ups
-Add support for updating CommandMenuItem based on the underlying Command's values changing.

Fix #277 
-Fix OpenFileCommandHandler so it checks editorProviders.Length

Add CanCreateNew property to IEditorProvider
-This is based on #229  . This is useful when you only support reading/saving certain file types, but not creating them from scratch.
-Gemini supports net461, which is C# 7.3. If it only targeted dotnet versions that supported C# 8.0, CanCreateNew could have been implemented using a default interface member.

Add null guard in ShellView.UpdateFloatingWindows
-Add DataContext null check in UpdateFloatingWindows to avoid exceptions in the XAML designer.

Tool touch ups
-Change Tool CloseCommand to function the same as Document's, where it invokes TryCloseAsync.
-Add Tool.TryCloseAsync override and set IsVisible=false.
-Change ShellViewModel.ShowTool so that it calls the model's ActivateAsync when also adding the model to the Tools collection.

Fix Solution Items
-Remove files which no longer exist, or were renamed.
-Add a few other files from the top level folder.

Refactors for files touched based on csharp_style_expression_bodied suggestions.