### PR TITLE
Update caliburn micro4.0.173 and fix PublishSingleFile

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": "Launch Gemini.Demo PublishSingleFile (.NET Core 3.1)",
+            "type": "coreclr",
+            "request": "launch",
+            // Don't pre-build, assumes you have already published the exe
+            //"preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/Gemini.Demo/bin/Debug/netcoreapp3.1/publish/Gemini.Demo.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}/Gemini.Demo/bin/Debug/netcoreapp3.1/publish/",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": "Launch Gemini.Demo PublishSingleFile (.NET5)",
+            "type": "coreclr",
+            "request": "launch",
+            // Don't pre-build, assumes you have already published the exe
+            //"preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/Gemini.Demo/bin/Debug/net5.0-windows/publish/Gemini.Demo.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}/Gemini.Demo/bin/Debug/net5.0-windows/publish/",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/src/Gemini.Demo/App.xaml
+++ b/src/Gemini.Demo/App.xaml
@@ -1,14 +1,18 @@
 <Application x:Class="Gemini.Demo.App"
-			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-			 xmlns:gemini="http://schemas.timjones.io/gemini">
-	<Application.Resources>
-		<ResourceDictionary>
-			<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary>
-					<gemini:AppBootstrapper x:Key="bootstrapper" />
-				</ResourceDictionary>
-			</ResourceDictionary.MergedDictionaries>
-		</ResourceDictionary>
-	</Application.Resources>
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:gemini="http://schemas.timjones.io/gemini"
+             xmlns:local="clr-namespace:Gemini.Demo"
+             >
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary>
+                    <gemini:AppBootstrapper x:Key="bootstrapper" />
+                    <!--Use this bootstrapper instead when you are testing the Demo under .NET5+ with PublishSingleFile-->
+                    <!--<local:DemoAppBootstrapper x:Key="bootstrapper" />-->
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/src/Gemini.Demo/DemoAppBootstrapper.cs
+++ b/src/Gemini.Demo/DemoAppBootstrapper.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Gemini.Demo
+{
+    /// <summary>
+    /// Only needed when you want Gemini.Demo to function under .NET5+ with PublishSingleFile
+    /// </summary>
+    public class DemoAppBootstrapper : Gemini.AppBootstrapper
+    {
+        public override bool IsPublishSingleFileHandled => true;
+
+        protected override IEnumerable<Assembly> PublishSingleFileBypassAssemblies
+        {
+            get
+            {
+                yield return Assembly.GetAssembly(typeof(Gemini.AppBootstrapper)); // GeminiWpf
+                yield return Assembly.GetAssembly(typeof(Gemini.Modules.CodeCompiler.ICodeCompiler));
+                yield return Assembly.GetAssembly(typeof(Gemini.Modules.CodeEditor.ILanguageDefinition));
+                yield return Assembly.GetAssembly(typeof(Gemini.Modules.ErrorList.IErrorList));
+                yield return Assembly.GetAssembly(typeof(Gemini.Modules.GraphEditor.Module));
+                yield return Assembly.GetAssembly(typeof(Gemini.Modules.Inspector.IInspectorTool));
+                yield return Assembly.GetAssembly(typeof(Gemini.Modules.Output.IOutput));
+                yield return Assembly.GetAssembly(typeof(Gemini.Modules.PropertyGrid.IPropertyGrid));
+                // add more assemblies with exports as needed here
+            }
+        }
+    };
+}

--- a/src/Gemini.Demo/Gemini.Demo.csproj
+++ b/src/Gemini.Demo/Gemini.Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>

--- a/src/Gemini.Demo/Properties/PublishProfiles/FolderProfileNet5.pubxml
+++ b/src/Gemini.Demo/Properties/PublishProfiles/FolderProfileNet5.pubxml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!--Use Debug config to avoid launching with optimizations enabled (making debugging PublishSingleFile harder)-->
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\net5.0-windows\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <!--Need to use x64 to debug with VS Code-->
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <DeleteExistingFiles>true</DeleteExistingFiles>
+    <!-- https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file#other-considerations
+         "Specifying IncludeAllContentForSelfExtract will extract all files before running the executable. This preserves the original .NET Core single-file deployment behavior" -->
+    <IncludeAllContentForSelfExtract>false</IncludeAllContentForSelfExtract>
+  </PropertyGroup>
+</Project>

--- a/src/Gemini.Demo/Properties/PublishProfiles/FolderProfileNetCore31.pubxml
+++ b/src/Gemini.Demo/Properties/PublishProfiles/FolderProfileNetCore31.pubxml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!--Use Debug config to avoid launching with optimizations enabled (making debugging PublishSingleFile harder)-->
+    <Configuration>Debug</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Debug\netcoreapp3.1\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <!--Need to use x64 to debug with VS Code-->
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <DeleteExistingFiles>true</DeleteExistingFiles>
+  </PropertyGroup>
+</Project>

--- a/src/Gemini.Modules.CodeCompiler/Gemini.Modules.CodeCompiler.csproj
+++ b/src/Gemini.Modules.CodeCompiler/Gemini.Modules.CodeCompiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell C# compile Roslyn</PackageTags>
     <Description>CodeCompiler module for Gemini, providing C# code compilation using Roslyn.</Description>
   </PropertyGroup>

--- a/src/Gemini.Modules.CodeEditor/Gemini.Modules.CodeEditor.csproj
+++ b/src/Gemini.Modules.CodeEditor/Gemini.Modules.CodeEditor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell C# syntax highlighting AvalonEdit</PackageTags>
     <Description>CodeEditor module for Gemini, providing a syntax-highlighted code editor using AvalonEdit.</Description>

--- a/src/Gemini.Modules.ErrorList/Gemini.Modules.ErrorList.csproj
+++ b/src/Gemini.Modules.ErrorList/Gemini.Modules.ErrorList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell error list</PackageTags>
     <Description>ErrorList module for Gemini, providing a tool window to display messages, warnings and errors.</Description>

--- a/src/Gemini.Modules.GraphEditor/Gemini.Modules.GraphEditor.csproj
+++ b/src/Gemini.Modules.GraphEditor/Gemini.Modules.GraphEditor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell graph node connector connection</PackageTags>
     <Description>GraphEditor module for Gemini, providing UI controls to edit a graph of connected nodes.</Description>

--- a/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
+++ b/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell inspector</PackageTags>
     <Description>Inspector module for Gemini, providing a flexible PropertyGrid-esque tool window.</Description>

--- a/src/Gemini.Modules.Output/Gemini.Modules.Output.csproj
+++ b/src/Gemini.Modules.Output/Gemini.Modules.Output.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell Output</PackageTags>
     <Description>Output module for Gemini, providing a buffered output tool pane.</Description>

--- a/src/Gemini.Modules.PropertyGrid/Gemini.Modules.PropertyGrid.csproj
+++ b/src/Gemini.Modules.PropertyGrid/Gemini.Modules.PropertyGrid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell PropertyGrid</PackageTags>
     <Description>PropertyGrid module for Gemini, utilising the PropertyGrid control from the Extended WPF Toolkit.</Description>

--- a/src/Gemini.sln
+++ b/src/Gemini.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29519.87
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Demo", "Gemini.Demo\Gemini.Demo.csproj", "{250E5DC8-DEE7-428E-8FE6-EAFDD70977EE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini.Demo", "Gemini.Demo\Gemini.Demo.csproj", "{250E5DC8-DEE7-428E-8FE6-EAFDD70977EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini", "Gemini\Gemini.csproj", "{13DBFC87-C152-4A86-94B0-D9944BEEF647}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini", "Gemini\Gemini.csproj", "{13DBFC87-C152-4A86-94B0-D9944BEEF647}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Modules.Output", "Gemini.Modules.Output\Gemini.Modules.Output.csproj", "{B78AACC8-5A16-4951-83AD-B78D1C80A258}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini.Modules.Output", "Gemini.Modules.Output\Gemini.Modules.Output.csproj", "{B78AACC8-5A16-4951-83AD-B78D1C80A258}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Modules.PropertyGrid", "Gemini.Modules.PropertyGrid\Gemini.Modules.PropertyGrid.csproj", "{8080CB9A-9389-4B4D-9ADF-BEF7FEFCAC55}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini.Modules.PropertyGrid", "Gemini.Modules.PropertyGrid\Gemini.Modules.PropertyGrid.csproj", "{8080CB9A-9389-4B4D-9ADF-BEF7FEFCAC55}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{748FD7C1-877B-451D-809A-68E032C39B34}"
 	ProjectSection(SolutionItems) = preProject
@@ -20,15 +20,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\version.json = ..\version.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Modules.Inspector", "Gemini.Modules.Inspector\Gemini.Modules.Inspector.csproj", "{0F8463BD-C1B0-4F2B-855D-49B6963B3337}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini.Modules.Inspector", "Gemini.Modules.Inspector\Gemini.Modules.Inspector.csproj", "{0F8463BD-C1B0-4F2B-855D-49B6963B3337}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Modules.ErrorList", "Gemini.Modules.ErrorList\Gemini.Modules.ErrorList.csproj", "{9F436232-52C4-4C2C-A83F-ADFE5B829484}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini.Modules.ErrorList", "Gemini.Modules.ErrorList\Gemini.Modules.ErrorList.csproj", "{9F436232-52C4-4C2C-A83F-ADFE5B829484}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Modules.CodeEditor", "Gemini.Modules.CodeEditor\Gemini.Modules.CodeEditor.csproj", "{1B56487B-CD40-4D94-8A62-C15F7E13D2FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini.Modules.CodeEditor", "Gemini.Modules.CodeEditor\Gemini.Modules.CodeEditor.csproj", "{1B56487B-CD40-4D94-8A62-C15F7E13D2FC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Modules.CodeCompiler", "Gemini.Modules.CodeCompiler\Gemini.Modules.CodeCompiler.csproj", "{F1CEEDDC-A1DC-4A7A-8A86-FA4C72BFBAE1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini.Modules.CodeCompiler", "Gemini.Modules.CodeCompiler\Gemini.Modules.CodeCompiler.csproj", "{F1CEEDDC-A1DC-4A7A-8A86-FA4C72BFBAE1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gemini.Modules.GraphEditor", "Gemini.Modules.GraphEditor\Gemini.Modules.GraphEditor.csproj", "{F8204886-1F61-4247-B7B2-EA5E518162F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gemini.Modules.GraphEditor", "Gemini.Modules.GraphEditor\Gemini.Modules.GraphEditor.csproj", "{F8204886-1F61-4247-B7B2-EA5E518162F3}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Demos", "Demos", "{87C5CCCC-7448-4802-B35F-C0BEA3FF880D}"
 EndProject

--- a/src/Gemini/AppBootstrapper.cs
+++ b/src/Gemini/AppBootstrapper.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.ReflectionModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -17,17 +18,22 @@ namespace Gemini
     {
         private List<Assembly> _priorityAssemblies;
 
-		protected CompositionContainer Container { get; set; }
+        protected CompositionContainer Container { get; set; }
 
         internal IList<Assembly> PriorityAssemblies
-        {
-            get { return _priorityAssemblies; }
-        }
+            => _priorityAssemblies;
+
+        /// <summary>
+        /// Override this to true if your main application properly handles PublishSingleFile cases.
+        /// Otherwise, an exception in <see cref="Configure"/> is thrown if Gemini detects
+        /// telltale signs of an PublishSingleFile environment under .NET5+.
+        /// </summary>
+        public virtual bool IsPublishSingleFileHandled => false;
 
         public AppBootstrapper()
         {
-            this.PreInitialize();
-            this.Initialize();
+            PreInitialize();
+            Initialize();
         }
 
         protected virtual void PreInitialize()
@@ -42,81 +48,154 @@ namespace Gemini
             }
         }
 
-		/// <summary>
-		/// By default, we are configured to use MEF
-		/// </summary>
-		protected override void Configure()
-		{
+        /// <summary>
+        /// By default, we are configured to use MEF
+        /// </summary>
+        protected override void Configure()
+        {
+            if (CheckIfGeminiAppearsPublishedToSingleFile())
+            {
+                if (!IsPublishSingleFileHandled)
+                {
+                    const string fullMethodName =
+                        nameof(Gemini) + "." +
+                        nameof(AppBootstrapper)+ "."+
+                        nameof(Configure);
+
+                    string exceptionMessage =
+                        "Gemini appears to be loaded by a .NET5+ app that was deployed with PublishSingleFile (.pubxml), or possibly loaded from memory. " +
+                        $"Set {nameof(IsPublishSingleFileHandled)} to true if you expect this and are handling it in your app. " +
+                        $"Otherwise, {fullMethodName} and MEF may not find your assemblies with exports.";
+
+                    // Need to show a message, else the program dies without any information to the user
+                    if (!System.Diagnostics.Debugger.IsAttached)
+                    {
+                        MessageBox.Show(exceptionMessage, "GeminiWpf");
+                    }
+
+                    var exception = new InvalidOperationException(exceptionMessage)
+                    {
+                        HelpLink = "https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file",
+                    };
+
+                    throw exception;
+                }
+
+                // First, add the assemblies which DirectoryCatalog can't find because they are embedded in the app.
+                // Unlike the "directoryCatalog.Parts" LINQ below, we don't try to filter out duplicate assemblies here.
+                AssemblySource.Instance.AddRange(PublishSingleFileBypassAssemblies);
+            }
+
+            // If these paths are different, it suggests this is a .netcoreapp3.1 PublishSingleFile,
+            // which extracts files to the Temp directory (AppContext.BaseDirectory).
+            // In .NET5+, the files are NOT extracted, unless IncludeAllContentForSelfExtract is set in the .pubxml.
+            // See https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file#other-considerations
+            string currentWorkingDir = Path.GetDirectoryName(Path.GetFullPath(@"./"));
+            string baseDirectory = Path.GetDirectoryName(Path.GetFullPath(AppContext.BaseDirectory));
+
             // Add all assemblies to AssemblySource (using a temporary DirectoryCatalog).
-            var directoryCatalog = new DirectoryCatalog(@"./");
-            AssemblySource.Instance.AddRange(
-                directoryCatalog.Parts
-                    .Select(part => ReflectionModelServices.GetPartType(part).Value.Assembly)
-                    .Where(assembly => !AssemblySource.Instance.Contains(assembly)));
+            PopulateAssemblySourceUsingDirectoryCatalog(currentWorkingDir);
+            if (currentWorkingDir != baseDirectory)
+            {
+                PopulateAssemblySourceUsingDirectoryCatalog(baseDirectory);
+            }
 
             // Prioritise the executable assembly. This allows the client project to override exports, including IShell.
             // The client project can override SelectAssemblies to choose which assemblies are prioritised.
             _priorityAssemblies = SelectAssemblies().ToList();
-		    var priorityCatalog = new AggregateCatalog(_priorityAssemblies.Select(x => new AssemblyCatalog(x)));
-		    var priorityProvider = new CatalogExportProvider(priorityCatalog);
-            
+            var priorityCatalog = new AggregateCatalog(_priorityAssemblies.Select(x => new AssemblyCatalog(x)));
+            var priorityProvider = new CatalogExportProvider(priorityCatalog);
+
             // Now get all other assemblies (excluding the priority assemblies).
-			var mainCatalog = new AggregateCatalog(
+            var mainCatalog = new AggregateCatalog(
                 AssemblySource.Instance
                     .Where(assembly => !_priorityAssemblies.Contains(assembly))
                     .Select(x => new AssemblyCatalog(x)));
-		    var mainProvider = new CatalogExportProvider(mainCatalog);
+            var mainProvider = new CatalogExportProvider(mainCatalog);
 
-			Container = new CompositionContainer(priorityProvider, mainProvider);
-		    priorityProvider.SourceProvider = Container;
-		    mainProvider.SourceProvider = Container;
+            Container = new CompositionContainer(priorityProvider, mainProvider);
+            priorityProvider.SourceProvider = Container;
+            mainProvider.SourceProvider = Container;
 
-			var batch = new CompositionBatch();
+            var batch = new CompositionBatch();
 
-		    BindServices(batch);
+            BindServices(batch);
             batch.AddExportedValue(mainCatalog);
 
-			Container.Compose(batch);
-		}
+            Container.Compose(batch);
+        }
 
-	    protected virtual void BindServices(CompositionBatch batch)
+        protected void PopulateAssemblySourceUsingDirectoryCatalog(string path)
+        {
+            var directoryCatalog = new DirectoryCatalog(path);
+            AssemblySource.Instance.AddRange(
+                directoryCatalog.Parts
+                    .Select(part => ReflectionModelServices.GetPartType(part).Value.Assembly)
+                    .Where(assembly => !AssemblySource.Instance.Contains(assembly)));
+        }
+
+        /// <summary>
+        /// Does a best-guess check to determine if Gemini was deployed under an app with
+        /// a PublishSingleFile configuration in .NET5+ environments.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual bool CheckIfGeminiAppearsPublishedToSingleFile()
+        {
+            var geminiAssembly = Assembly.GetAssembly(typeof(Gemini.AppBootstrapper));
+
+            // https://github.com/dotnet/runtime/issues/36590 "Support Single-File Apps in .NET 5"
+
+            // https://github.com/dotnet/designs/blob/main/accepted/2020/single-file/design.md#assemblylocation
+            // "Proposed solution is for Assembly.Location to return the empty-string for bundled assemblies, which is the default behavior for assemblies loaded from memory."
+            // https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file#api-incompatibility
+            // I suppose it may be possible that some .NET obfuscators and "protectors" would lead to this behavior, so this should
+            if (geminiAssembly.Location == string.Empty)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// When your application is deployed using PublishSingleFile under .NET5+, override
+        /// this to explicitly list the assemblies that MEF needs to search exports for.
+        /// </summary>
+        protected virtual IEnumerable<Assembly> PublishSingleFileBypassAssemblies
+            => Enumerable.Empty<Assembly>();
+
+        protected virtual void BindServices(CompositionBatch batch)
         {
             batch.AddExportedValue<IWindowManager>(new WindowManager());
             batch.AddExportedValue<IEventAggregator>(new EventAggregator());
             batch.AddExportedValue(Container);
-	        batch.AddExportedValue(this);
+            batch.AddExportedValue(this);
         }
 
-		protected override object GetInstance(Type serviceType, string key)
-		{
-			string contract = string.IsNullOrEmpty(key) ? AttributedModelServices.GetContractName(serviceType) : key;
-			var exports = Container.GetExports<object>(contract);
+        protected override object GetInstance(Type serviceType, string key)
+        {
+            string contract = string.IsNullOrEmpty(key) ? AttributedModelServices.GetContractName(serviceType) : key;
+            var exports = Container.GetExports<object>(contract);
 
-			if (exports.Any())
-				return exports.First().Value;
+            if (exports.Any())
+                return exports.First().Value;
 
-			throw new Exception(string.Format("Could not locate any instances of contract {0}.", contract));
-		}
+            throw new Exception(string.Format("Could not locate any instances of contract {0}.", contract));
+        }
 
-		protected override IEnumerable<object> GetAllInstances(Type serviceType)
-		{
-			return Container.GetExportedValues<object>(AttributedModelServices.GetContractName(serviceType));
-		}
+        protected override IEnumerable<object> GetAllInstances(Type serviceType)
+            => Container.GetExportedValues<object>(AttributedModelServices.GetContractName(serviceType));
 
-		protected override void BuildUp(object instance)
-		{
-			Container.SatisfyImportsOnce(instance);
-		}
+        protected override void BuildUp(object instance)
+            => Container.SatisfyImportsOnce(instance);
 
-	    protected override void OnStartup(object sender, StartupEventArgs e)
-	    {
-	        base.OnStartup(sender, e);
+        protected override void OnStartup(object sender, StartupEventArgs e)
+        {
+            base.OnStartup(sender, e);
             DisplayRootViewFor<IMainWindow>();
-	    }
+        }
 
         protected override IEnumerable<Assembly> SelectAssemblies()
-        {
-            return new[] { Assembly.GetEntryAssembly() };
-        }
-	}
+            => new[] { Assembly.GetEntryAssembly() };
+    };
 }

--- a/src/Gemini/Framework/Results/OpenDocumentResult.cs
+++ b/src/Gemini/Framework/Results/OpenDocumentResult.cs
@@ -14,7 +14,7 @@ namespace Gemini.Framework.Results
 
 #pragma warning disable 649
         [Import]
-		private IShell _shell;
+		private readonly IShell _shell;
 #pragma warning restore 649
 
         public OpenDocumentResult(IDocument editor)
@@ -53,12 +53,14 @@ namespace Gemini.Framework.Results
 
 			editor.Deactivated += (s, e) =>
 			{
-				if (!e.WasClosed)
-					return;
+                if (e.WasClosed)
+                {
+                    if (_onShutDown != null)
+                        _onShutDown(editor);
+                }
 
-				if (_onShutDown != null)
-					_onShutDown(editor);
-			};
+                return System.Threading.Tasks.Task.CompletedTask;
+            };
 
 			_shell
                 .OpenDocumentAsync(editor)

--- a/src/Gemini/Framework/Results/ShowToolResult.cs
+++ b/src/Gemini/Framework/Results/ShowToolResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.Composition;
 using Caliburn.Micro;
 using Gemini.Framework.Services;
@@ -12,7 +12,7 @@ namespace Gemini.Framework.Results
 
 #pragma warning disable 649
         [Import]
-		private IShell _shell;
+		private readonly IShell _shell;
 #pragma warning restore 649
 
         public ShowToolResult()
@@ -37,14 +37,16 @@ namespace Gemini.Framework.Results
 
 			tool.Deactivated += (s, e) =>
 			{
-				if (!e.WasClosed)
-					return;
+                if (e.WasClosed)
+                {
+                    if (_onShutDown != null)
+                        _onShutDown(tool);
 
-				if (_onShutDown != null)
-					_onShutDown(tool);
+                    OnCompleted(null, false);
+                }
 
-				OnCompleted(null, false);
-			};
+                return System.Threading.Tasks.Task.CompletedTask;
+            };
 
 			_shell.ShowTool(tool);
 		}

--- a/src/Gemini/Framework/Results/ShowWindowResult.cs
+++ b/src/Gemini/Framework/Results/ShowWindowResult.cs
@@ -14,7 +14,6 @@ namespace Gemini.Framework.Results
 
         public ShowWindowResult()
         {
-            
         }
 
         public ShowWindowResult(TWindow window)
@@ -34,13 +33,15 @@ namespace Gemini.Framework.Results
 
             window.Deactivated += (s, e) =>
             {
-                if (!e.WasClosed)
-                    return;
+                if (e.WasClosed)
+                {
+                    if (_onShutDown != null)
+                        _onShutDown(window);
 
-                if (_onShutDown != null)
-                    _onShutDown(window);
+                    OnCompleted(null, false);
+                }
 
-                OnCompleted(null, false);
+                return System.Threading.Tasks.Task.CompletedTask;
             };
 
             WindowManager.ShowWindowAsync(window);

--- a/src/Gemini/Gemini.csproj
+++ b/src/Gemini/Gemini.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageId>GeminiWpf</PackageId>
     <Title>Gemini</Title>
@@ -52,11 +52,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.104-alpha" />
+    <PackageReference Include="Caliburn.Micro" Version="4.0.173" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="3.6.2" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="4.6.78" />
     <PackageReference Include="MahApps.Metro" Version="2.0.0-alpha0660" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" Condition="$(TargetFramework) == 'net461'" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Add net5.0-windows target.

Upgrade Caliburn.Micro from 4.0.104-alpha to 4.0.173 and make trivial changes in response to API changes around IDeactivate, which was changed to async. See https://github.com/Caliburn-Micro/Caliburn.Micro/commit/11d3d8207fd0e2aaf8f6956d791bb5f0ba2b037f.

Fix PublishSingleFile under .netcoreapp3.1. Files are extracted to a temp folder, so in addition to the CWD, AppContext.BaseDirectory must be enumerated by a DirectoryCatalog.

Fix PublishSingleFile under .net5.0-windows (and later, I imagine). Unlike .netcore, files are NOT extracted, unless you specify IncludeAllContentForSelfExtract=true in the .pubxml.

Add new DemoAppBootstrapper implementation to showcase how to support PublishSingleFile cases under .NET5. It is not used by default, requires user to change App.xaml.

Add .pubxml files for testing PublishSingleFile under .netcoreapp3.1 and .net5.0-windows.
Add vscode\launch.json for easy launch-and-debugging (with VS Code).

Under .NET5+, when PublishSingleFile is detected and there's no debugger, Gemini.AppBootstrapper.Config will present a message box with the message which also gets thrown as an exception. This is because when not under a debugger, the app crashes with no information (Gemini.Demo.App crash). When a debugger is present, only the exception is thrown.