### PR TITLE
Handle toolbar command visibility, hide toolbar/menu separators when unnecessary

### DIFF
--- a/src/Gemini/Framework/Commands/Command.cs
+++ b/src/Gemini/Framework/Commands/Command.cs
@@ -21,61 +21,37 @@ namespace Gemini.Framework.Commands
         public bool Visible
         {
             get { return _visible; }
-            set
-            {
-                _visible = value;
-                NotifyOfPropertyChange(() => Visible);
-            }
+            set { Set(ref _visible, value); }
         }
 
         public bool Enabled
         {
             get { return _enabled; }
-            set
-            {
-                _enabled = value;
-                NotifyOfPropertyChange(() => Enabled);
-            }
+            set { Set(ref _enabled, value); }
         }
 
         public bool Checked
         {
             get { return _checked; }
-            set
-            {
-                _checked = value;
-                NotifyOfPropertyChange(() => Checked);
-            }
+            set { Set(ref _checked, value); }
         }
 
         public string Text
         {
             get { return _text; }
-            set
-            {
-                _text = value;
-                NotifyOfPropertyChange(() => Text);
-            }
+            set { Set(ref _text, value); }
         }
 
         public string ToolTip
         {
             get { return _toolTip; }
-            set
-            {
-                _toolTip = value;
-                NotifyOfPropertyChange(() => ToolTip);
-            }
+            set { Set(ref _toolTip, value); }
         }
 
         public Uri IconSource
         {
             get { return _iconSource; }
-            set
-            {
-                _iconSource = value;
-                NotifyOfPropertyChange(() => IconSource);
-            }
+            set { Set(ref _iconSource, value); }
         }
 
         public object Tag { get; set; }

--- a/src/Gemini/Framework/Utils/ItemsControlUtility.cs
+++ b/src/Gemini/Framework/Utils/ItemsControlUtility.cs
@@ -1,0 +1,50 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Gemini.Framework.Utils
+{
+    public static class ItemsControlUtility
+    {
+        public static void UpdateSeparatorsVisibility(ItemsControl itemsControl)
+        {
+            Separator lastSeparator = null;
+            var foundItemsBefore = false;
+            var foundItemsAfter = false;
+
+            var itemsCount = itemsControl.Items.Count;
+            for (int i = 0; i < itemsCount; i++)
+            {
+                var container = itemsControl.ItemContainerGenerator.ContainerFromIndex(i);
+                switch (container)
+                {
+                    case Separator newSeparator:
+                        if (lastSeparator != null)
+                        {
+                            lastSeparator.Visibility = foundItemsBefore && foundItemsAfter ? Visibility.Visible : Visibility.Collapsed;
+
+                            // If last separator is not visible, items found before it should still be considered as item found before next separator.
+                            if (lastSeparator.Visibility != Visibility.Visible)
+                            {
+                                foundItemsBefore = foundItemsBefore || foundItemsAfter;
+                                foundItemsAfter = false;
+                                lastSeparator = newSeparator;
+                                break;
+                            }
+                        }
+
+                        foundItemsBefore = foundItemsAfter;
+                        foundItemsAfter = false;
+                        lastSeparator = newSeparator;
+                        break;
+
+                    case UIElement uiElement when uiElement.Visibility == Visibility.Visible:
+                        foundItemsAfter = true;
+                        break;
+                }
+            }
+
+            if (lastSeparator != null)
+                lastSeparator.Visibility = foundItemsBefore && foundItemsAfter ? Visibility.Visible : Visibility.Collapsed;
+        }
+    }
+}

--- a/src/Gemini/Modules/MainMenu/Controls/MenuItemEx.cs
+++ b/src/Gemini/Modules/MainMenu/Controls/MenuItemEx.cs
@@ -1,6 +1,9 @@
-﻿using System.Windows;
+using System;
+using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
 using Gemini.Framework.Controls;
+using Gemini.Framework.Utils;
 using Gemini.Modules.MainMenu.Models;
 
 namespace Gemini.Modules.MainMenu.Controls
@@ -32,5 +35,32 @@ namespace Gemini.Modules.MainMenu.Controls
 		    result.SetResourceReference(DynamicStyle.DerivedStyleProperty, styleKey);
 		    return result;
 		}
-	}
+
+        protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
+        {
+            base.PrepareContainerForItemOverride(element, item);
+
+            if (!(element is Separator))
+            {
+                ItemsControlUtility.UpdateSeparatorsVisibility(this);
+                DependencyPropertyDescriptor.FromProperty(VisibilityProperty, element.GetType()).AddValueChanged(element, UpdateSeparatorsVisibility);
+            }
+        }
+
+        protected override void ClearContainerForItemOverride(DependencyObject element, object item)
+        {
+            if (!(element is Separator))
+            {
+                DependencyPropertyDescriptor.FromProperty(VisibilityProperty, element.GetType()).RemoveValueChanged(element, UpdateSeparatorsVisibility);
+                ItemsControlUtility.UpdateSeparatorsVisibility(this);
+            }
+
+            base.ClearContainerForItemOverride(element, item);
+        }
+
+        private void UpdateSeparatorsVisibility(object sender, EventArgs e)
+        {
+            ItemsControlUtility.UpdateSeparatorsVisibility(this);
+        }
+    }
 }

--- a/src/Gemini/Modules/ToolBars/Controls/ToolBarBase.cs
+++ b/src/Gemini/Modules/ToolBars/Controls/ToolBarBase.cs
@@ -1,6 +1,9 @@
-﻿using System.Windows;
+using System;
+using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
 using Gemini.Framework.Controls;
+using Gemini.Framework.Utils;
 using Gemini.Modules.ToolBars.Models;
 
 namespace Gemini.Modules.ToolBars.Controls
@@ -33,6 +36,33 @@ namespace Gemini.Modules.ToolBars.Controls
             result.SetResourceReference(DynamicStyle.BaseStyleProperty, baseStyleKey);
             result.SetResourceReference(DynamicStyle.DerivedStyleProperty, styleKey);
             return result;
+        }
+
+        protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
+        {
+            base.PrepareContainerForItemOverride(element, item);
+
+            if (!(element is Separator))
+            {
+                ItemsControlUtility.UpdateSeparatorsVisibility(this);
+                DependencyPropertyDescriptor.FromProperty(VisibilityProperty, element.GetType()).AddValueChanged(element, UpdateSeparatorsVisibility);
+            }
+        }
+
+        protected override void ClearContainerForItemOverride(DependencyObject element, object item)
+        {
+            if (!(element is Separator))
+            {
+                DependencyPropertyDescriptor.FromProperty(VisibilityProperty, element.GetType()).RemoveValueChanged(element, UpdateSeparatorsVisibility);
+                ItemsControlUtility.UpdateSeparatorsVisibility(this);
+            }
+
+            base.ClearContainerForItemOverride(element, item);
+        }
+
+        private void UpdateSeparatorsVisibility(object sender, EventArgs e)
+        {
+            ItemsControlUtility.UpdateSeparatorsVisibility(this);
         }
     }
 }

--- a/src/Gemini/Modules/ToolBars/Models/CommandToolBarItem.cs
+++ b/src/Gemini/Modules/ToolBars/Models/CommandToolBarItem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Input;
 using Caliburn.Micro;
 using Gemini.Framework.Commands;
@@ -57,6 +58,11 @@ namespace Gemini.Modules.ToolBars.Models
             get { return _command.Checked; }
         }
 
+        public Visibility Visibility
+        {
+            get { return _command.Visible ? Visibility.Visible : Visibility.Collapsed; }
+        }
+
 		public CommandToolBarItem(ToolBarItemDefinition toolBarItem, Command command, IToolBar parent)
 		{
 		    _toolBarItem = toolBarItem;
@@ -69,11 +75,25 @@ namespace Gemini.Modules.ToolBars.Models
 
         private void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            NotifyOfPropertyChange(() => Text);
-            NotifyOfPropertyChange(() => IconSource);
-            NotifyOfPropertyChange(() => ToolTip);
-            NotifyOfPropertyChange(() => HasToolTip);
-            NotifyOfPropertyChange(() => IsChecked);
+            switch (e.PropertyName)
+            {
+                case nameof(Framework.Commands.Command.Text):
+                    NotifyOfPropertyChange(nameof(Text));
+                    break;
+                case nameof(Framework.Commands.Command.IconSource):
+                    NotifyOfPropertyChange(nameof(IconSource));
+                    break;
+                case nameof(Framework.Commands.Command.ToolTip):
+                    NotifyOfPropertyChange(nameof(ToolTip));
+                    NotifyOfPropertyChange(nameof(HasToolTip));
+                    break;
+                case nameof(Framework.Commands.Command.Checked):
+                    NotifyOfPropertyChange(nameof(IsChecked));
+                    break;
+                case nameof(Framework.Commands.Command.Visible):
+                    NotifyOfPropertyChange(nameof(Visibility));
+                    break;
+            }
         }
 
 	    CommandDefinitionBase ICommandUiItem.CommandDefinition

--- a/src/Gemini/Modules/ToolBars/Resources/Styles.xaml
+++ b/src/Gemini/Modules/ToolBars/Resources/Styles.xaml
@@ -27,6 +27,7 @@
         <Setter Property="ToolTip" Value="{Binding ToolTip}" />
         <Setter Property="ToolTipService.IsEnabled" Value="{Binding HasToolTip}" />
 		<Setter Property="IsChecked" Value="{Binding IsChecked, Mode=OneWay}" />
+        <Setter Property="Visibility" Value="{Binding Visibility, Mode=OneWay}" />
         <Setter Property="Command" Value="{Binding Command}" />
         <Setter Property="CommandParameter" Value="{Binding RelativeSource={RelativeSource Self}}" />
 


### PR DESCRIPTION
I added toolbar item binding on command visibility so it behave the same as menu item.

Because of that, I improved MenuItemEx and ToolBarBase so they call a new helper `ItemsControlUtility.UpdateSeparatorsVisibility` on added/removed items or item visibility changes. It prevent separators to appear at toolbar/menu start or end, or to have multiple successive separators since it might be possible with visibility changes.

I also updated `CommandTooBarItem` with changes on PropertyChanged handler, similar to `CommandMenuItem` ones done by commit f3de641.

Finally, command properties now use Set(). It will prevent PropertyChanged to be raised when values are not changing.

![image](https://user-images.githubusercontent.com/7021265/116823110-f9348900-ab82-11eb-8fc5-aa73bea28aed.png)
![image](https://user-images.githubusercontent.com/7021265/116823104-f2a61180-ab82-11eb-8718-090fd65720ff.png)
![image](https://user-images.githubusercontent.com/7021265/116823082-c68a9080-ab82-11eb-9112-b36726895ffa.png)
![image](https://user-images.githubusercontent.com/7021265/116823095-e0c46e80-ab82-11eb-99c2-c51f616b8e18.png)


