### PR TITLE
Support icon for editor file types

### DIFF
--- a/src/Gemini/Framework/Services/EditorFileType.cs
+++ b/src/Gemini/Framework/Services/EditorFileType.cs
@@ -1,14 +1,18 @@
-﻿namespace Gemini.Framework.Services
+using System;
+
+namespace Gemini.Framework.Services
 {
     public class EditorFileType
     {
         public string Name { get; set; }
         public string FileExtension { get; set; }
+        public Uri IconSource { get; set; }
 
-        public EditorFileType(string name, string fileExtension)
+        public EditorFileType(string name, string fileExtension, Uri iconSource = null)
         {
             Name = name;
             FileExtension = fileExtension;
+            IconSource = iconSource;
         }
 
         public EditorFileType()

--- a/src/Gemini/Modules/Shell/Commands/NewFileCommandHandler.cs
+++ b/src/Gemini/Modules/Shell/Commands/NewFileCommandHandler.cs
@@ -38,6 +38,7 @@ namespace Gemini.Modules.Shell.Commands
                     commands.Add(new Command(command.CommandDefinition)
                     {
                         Text = editorFileType.Name,
+                        IconSource = editorFileType.IconSource,
                         Tag = new NewFileTag
                         {
                             EditorProvider = editorProvider,


### PR DESCRIPTION
Allow to provide an optional icon for editor file types, showing in "File > New" menu.

![image](https://user-images.githubusercontent.com/7021265/116823329-1e75c700-ab84-11eb-899c-e018e5461779.png)