### PR TITLE
Remove mnemonics shortcut marks for tool bar items.

### DIFF
--- a/src/Gemini/Modules/ToolBars/Models/CommandToolBarItem.cs
+++ b/src/Gemini/Modules/ToolBars/Models/CommandToolBarItem.cs
@@ -17,7 +17,7 @@ namespace Gemini.Modules.ToolBars.Models
 
 		public string Text
 		{
-			get { return _command.Text; }
+			get { return TrimMnemonics(_command.Text); }
 		}
 
         public ToolBarItemDisplay Display
@@ -85,5 +85,31 @@ namespace Gemini.Modules.ToolBars.Models
 	    {
 	        // TODO
 	    }
+
+        /// <summary>
+        /// Remove mnemonics underscores used by menu from text.
+        /// Also replace escaped/double underscores by a single underscore.
+        /// </summary>
+        private static string TrimMnemonics(string text)
+        {
+            var resultArray = new char[text.Length];
+
+            int resultLength = 0;
+            bool previousWasUnderscore = false;
+            for (int textIndex = 0; textIndex < text.Length; textIndex++)
+            {
+                char c = text[textIndex];
+                if (c == '_' && !previousWasUnderscore)
+                {
+                    previousWasUnderscore = true;
+                    continue;
+                }
+
+                previousWasUnderscore = false;
+                resultArray[resultLength++] = c;
+            }
+
+            return new string(resultArray, 0, resultLength);
+        }
     }
 }

--- a/src/Gemini/Modules/ToolBars/Models/CommandToolBarItem.cs
+++ b/src/Gemini/Modules/ToolBars/Models/CommandToolBarItem.cs
@@ -87,8 +87,9 @@ namespace Gemini.Modules.ToolBars.Models
 	    }
 
         /// <summary>
-        /// Remove mnemonics underscores used by menu from text.
+        /// Remove mnemonics underscore used by menu from text.
         /// Also replace escaped/double underscores by a single underscore.
+        /// Displayed text will be the same than with a menu item.
         /// </summary>
         private static string TrimMnemonics(string text)
         {
@@ -96,18 +97,50 @@ namespace Gemini.Modules.ToolBars.Models
 
             int resultLength = 0;
             bool previousWasUnderscore = false;
+            bool mnemonicsFound = false;
+
             for (int textIndex = 0; textIndex < text.Length; textIndex++)
             {
                 char c = text[textIndex];
-                if (c == '_' && !previousWasUnderscore)
+
+                if (c == '_')
                 {
-                    previousWasUnderscore = true;
-                    continue;
+                    if (!previousWasUnderscore)
+                    {
+                        // If previous character was not an underscore but the current is one, we set the flag.
+                        previousWasUnderscore = true;
+
+                        // Also, if mnemonics mark was not found yet, we also skip that underscore in result.
+                        if (!mnemonicsFound)
+                            continue;
+                    }
+                    else
+                    {
+                        // If both current and previous character are underscores, it is an escaped underscore.
+                        // We will include that second underscore in result and restore the flag.
+                        previousWasUnderscore = false;
+
+                        // If mnemonics mark was already found, previous underscore was included in result so we can escape this one.
+                        if (mnemonicsFound)
+                            continue;
+                    }
+                }
+                else
+                {
+                    // If previous character was an underscore and the current is not one, we found the mnemonics mark.
+                    // We will stop to search and include all the following characters, except escaped underscores, in result.
+                    if (!mnemonicsFound && previousWasUnderscore)
+                        mnemonicsFound = true;
+
+                    previousWasUnderscore = false;
                 }
 
-                previousWasUnderscore = false;
                 resultArray[resultLength++] = c;
             }
+
+            // If last character was an underscore and mnemonics mark was not found, it should be included in result.
+            if (previousWasUnderscore && !mnemonicsFound)
+                resultArray[resultLength++] = '_';
 
             return new string(resultArray, 0, resultLength);
         }


### PR DESCRIPTION
Tool bar item and menu item can both display the command text but only menu items handle underscore used as mnemonics shortcut marks.

This changes make the tool bar item display the same text as menu item when using `IconAndText` display mode.

Here is an example with `_O__p_en`, `S__a__v_e` and `Save All_` commands, edited to show edge cases :

![image](https://user-images.githubusercontent.com/7021265/116825676-86320f00-ab90-11eb-9701-94864a475af0.png)
![image](https://user-images.githubusercontent.com/7021265/116825755-de691100-ab90-11eb-9707-0b39702ae63c.png)
