### PR TITLE
Add alternative checked visual for menu items with icons

### DIFF
--- a/src/Gemini/Modules/MainMenu/Resources/Styles.xaml
+++ b/src/Gemini/Modules/MainMenu/Resources/Styles.xaml
@@ -16,6 +16,11 @@
         <Setter Property="IsChecked" Value="{Binding IsChecked, Mode=OneWay}" />
         <Setter Property="Command" Value="{Binding Command}" />
         <Setter Property="b:MenuBehavior.UpdateCommandUiItems" Value="True" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding IconSource}" Value="{x:Null}">
+                <Setter Property="Icon" Value="{x:Null}" />
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
 	<HierarchicalDataTemplate x:Key="menuTemplate" ItemsSource="{Binding Children}">

--- a/src/Gemini/Themes/VS2013/Controls/Menu.xaml
+++ b/src/Gemini/Themes/VS2013/Controls/Menu.xaml
@@ -145,24 +145,15 @@
                 </Grid.RowDefinitions>
                 <Border x:Name="IconContainer" Grid.Column="0" 
                         Background="Transparent"
-                        Padding="5,3,4,3">
-                    <Grid>
+                        Padding="2,0,1,0">
+                    <Border x:Name="IconBorder"
+                            BorderThickness="1">
                         <ContentPresenter x:Name="Icon"
                                           HorizontalAlignment="Center" 
                                           VerticalAlignment="Center"
                                           Height="16" Width="16"
                                           ContentSource="Icon" />
-                        <Border x:Name="Check" 
-                                VerticalAlignment="Center" HorizontalAlignment="Center" 
-                                Width="16" Height="16"
-                                Visibility="Collapsed"
-                                Background="{DynamicResource MenuPopupDefaultCheckmarkBackground}" 
-                                BorderThickness="0" BorderBrush="{DynamicResource MenuPopupDefaultCheckmark}">
-                            <Path x:Name="CheckMark" Width="8" Height="8" SnapsToDevicePixels="False"
-                                  Stroke="{DynamicResource MenuPopupDefaultCheckmark}" StrokeThickness="2" 
-                                  Data="M 0 4 L 3 7 7 0" />
-                        </Border>
-                    </Grid>
+                    </Border>
                 </Border>
                 <Border Grid.Column="1" Padding="6 2 0 2">
                     <ContentPresenter x:Name="HeaderHost" 
@@ -179,12 +170,9 @@
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
-            <Trigger Property="Icon" Value="{x:Null}">
-                <Setter TargetName="Icon" Property="Visibility" Value="Hidden" />
-            </Trigger>
             <Trigger Property="IsChecked" Value="true">
-                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
-                <Setter TargetName="Check" Property="Visibility" Value="Visible" />
+                <Setter TargetName="IconBorder" Property="BorderBrush" Value="{DynamicResource ToolbarButtonCheckedBorder}" />
+                <Setter TargetName="IconBorder" Property="Background" Value="{DynamicResource MenuPopupHoveredItemBackground}" />
             </Trigger>
             <Trigger Property="IsHighlighted" Value="true">
                 <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuPopupHoveredItemBackground}" />

--- a/src/Gemini/Themes/VS2013/Controls/Menu.xaml
+++ b/src/Gemini/Themes/VS2013/Controls/Menu.xaml
@@ -146,14 +146,27 @@
                 <Border x:Name="IconContainer" Grid.Column="0" 
                         Background="Transparent"
                         Padding="2,0,1,0">
-                    <Border x:Name="IconBorder"
-                            BorderThickness="1">
-                        <ContentPresenter x:Name="Icon"
-                                          HorizontalAlignment="Center" 
-                                          VerticalAlignment="Center"
-                                          Height="16" Width="16"
-                                          ContentSource="Icon" />
-                    </Border>
+                    <Grid>
+                        <Border x:Name="Check"
+                                Margin="3"
+                                VerticalAlignment="Center" HorizontalAlignment="Center" 
+                                Width="16" Height="16"
+                                Visibility="Collapsed"
+                                Background="{DynamicResource MenuPopupDefaultCheckmarkBackground}" 
+                                BorderThickness="0" BorderBrush="{DynamicResource MenuPopupDefaultCheckmark}">
+                            <Path x:Name="CheckMark" Width="8" Height="8" SnapsToDevicePixels="False"
+                                  Stroke="{DynamicResource MenuPopupDefaultCheckmark}" StrokeThickness="2" 
+                                  Data="M 0 4 L 3 7 7 0" />
+                        </Border>
+                        <Border x:Name="IconBorder"
+                                BorderThickness="1">
+                            <ContentPresenter x:Name="Icon"
+                                              HorizontalAlignment="Center" 
+                                              VerticalAlignment="Center"
+                                              Height="16" Width="16"
+                                              ContentSource="Icon" />
+                        </Border>
+                    </Grid>
                 </Border>
                 <Border Grid.Column="1" Padding="6 2 0 2">
                     <ContentPresenter x:Name="HeaderHost" 
@@ -170,7 +183,11 @@
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter TargetName="IconBorder" Property="Visibility" Value="Hidden" />
+            </Trigger>
             <Trigger Property="IsChecked" Value="true">
+                <Setter TargetName="Check" Property="Visibility" Value="Visible" />
                 <Setter TargetName="IconBorder" Property="BorderBrush" Value="{DynamicResource ToolbarButtonCheckedBorder}" />
                 <Setter TargetName="IconBorder" Property="Background" Value="{DynamicResource MenuPopupHoveredItemBackground}" />
             </Trigger>


### PR DESCRIPTION
Menu item icons were replaced by a check mark when checked. I added an alternative visual for menu items with icon.

Here is the difference with a checked "Open" command with icon and a checked "Open Graph" command without icon :

![image](https://user-images.githubusercontent.com/7021265/116830368-de293f80-aba9-11eb-83f0-44a6c673effb.png)
![image](https://user-images.githubusercontent.com/7021265/116830375-eb462e80-aba9-11eb-8e02-ece87909c104.png)



