### PR TITLE
Fix tools loading at start, preventing performance issue on commands update

### DIFF
--- a/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
+++ b/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
@@ -193,7 +193,7 @@ namespace Gemini.Modules.Shell.Services
                         }
                     }
 
-                    shellView.LoadLayout(reader.BaseStream, shell.Tools.Add, d => shell.OpenDocumentAsync(d).Wait(), layoutItems);
+                    shellView.LoadLayout(reader.BaseStream, t => AddTool(shell, t), d => shell.OpenDocumentAsync(d).Wait(), layoutItems);
                 }
             }
             catch
@@ -202,6 +202,12 @@ namespace Gemini.Modules.Shell.Services
             }
 
             return true;
+        }
+
+        private void AddTool(IShell shell, ITool tool)
+        {
+            if (!shell.Tools.Contains(tool))
+                shell.Tools.Add(tool);
         }
     }
 }

--- a/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
+++ b/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
@@ -193,7 +193,7 @@ namespace Gemini.Modules.Shell.Services
                         }
                     }
 
-                    shellView.LoadLayout(reader.BaseStream, shell.ShowTool, d => shell.OpenDocumentAsync(d).Wait(), layoutItems);
+                    shellView.LoadLayout(reader.BaseStream, shell.Tools.Add, d => shell.OpenDocumentAsync(d).Wait(), layoutItems);
                 }
             }
             catch

--- a/src/Gemini/Modules/Shell/Views/LayoutUtility.cs
+++ b/src/Gemini/Modules/Shell/Views/LayoutUtility.cs
@@ -40,7 +40,7 @@ namespace Gemini.Modules.Shell.Views
                             addToolCallback(tool);
                             tool.IsVisible = anchorable.IsVisible;
 
-                            if (anchorable.IsActive)
+                            if (anchorable.IsVisible)
                                 tool.ActivateAsync(CancellationToken.None).Wait();
 
                             tool.IsSelected = e.Model.IsSelected;


### PR DESCRIPTION
I encountered huge performance issue (if not a performance "blocker") at application start when I had at least one hidden tool in the restored layout. I was unable to do anything because of how busy the application was.

After some profiling, I found it was coming from the call to `ViewLocator.LocateForModel` in `CommandRouter.GetCommandHandlerForLayoutItem`. The problem is that when hidden tools are restored at loading, **they are set as `ActiveLayoutItem` despite not being shown and having no view attached to the view model**.
So when the `ViewLocator.LocateForModel` is called, it doesn't find a view from the view model provided by `ActiveLayoutItem` and instantiate a new view instance (without attaching it). And it does it every time commands are updated (on every click) and for every existing command, explaining the performance issue.

The more that view is costly to instantiate and the more commands you have, the more your application will be busy. The fact that Gemini.Demo has few commands and, more importantly, open some documents by default also explain why it was not encountered before (since `ActiveLayoutItem` will be set after layout loading with opened documents).

I suggest to fix it by **replacing the callback to `IShell.ShowTool` by simply `IShell.Tools.Add` when loading layout**. Calling `ShellViewModel.ShowTool` is setting `ActiveLayoutItem` and that's why we are encountering the issue in the end. 

Here is my thinking :

1. We don't have to set `ActiveLayoutItem` at layout loading because it has no useful behavior or visual effects on application starting state. (`ILayoutItem.IsSelected` property is the one restoring the top tool for each docking space.)
2. A null `ActiveLayoutItem` should not be an issue since CommandRouter is the only class outside of the shell itself to use `ActiveLayoutItem` and already handle a null reference.
3. `LayoutUtility.LoadLayout` was already doing works similar to `IShell.ShowTool` : it sets `IsVisible` & `IsSelected` with restored layout data and call `ActivateAsync` if necessary.

Considering all those points, the provided `addToolCallback` only have to be `IShell.Tools.Add`.
I also fixed the condition of call to `ActivateAsync`at layout loading : `LayoutContent.IsActive` is actually not restored (it has a `XmlIgnore` attribute) and is always false. To keep it coherent with `IShell.ShowTool` behavior, I suggest to replace it with a check on `LayoutAnchorable.IsVisible`.

EDIT: I added a `AddTool` method to LayoutItemStatePersister to also check if tool already exist, as ShowTool was doing. Without that, loading a layout at runtime was not working (anymore ?). I didn't add it to the `IShell` interface because it's a loading-only behaviour and it would be a bit ambiguous with `ShowTool`.