### PR TITLE
RefreshGridColumns() add null check

### DIFF
--- a/src/Gemini/Modules/StatusBar/Views/StatusBarView.xaml.cs
+++ b/src/Gemini/Modules/StatusBar/Views/StatusBarView.xaml.cs
@@ -25,6 +25,8 @@ namespace Gemini.Modules.StatusBar.Views
 
         public void RefreshGridColumns()
         {
+            if (_statusBarGrid is null)
+                return;
             _statusBarGrid.ColumnDefinitions.Clear();
             foreach (var item in StatusBar.Items.Cast<StatusBarItemViewModel>())
                 _statusBarGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = item.Width });


### PR DESCRIPTION
fix for https://github.com/tgjones/gemini/pull/337#issuecomment-1038517917

View get null when Toolbox hasn't been never opened.