### PR TITLE
Ensure tools are activated when shown, clean Tool implementation

### DIFF
--- a/src/Gemini/Framework/Services/IShell.cs
+++ b/src/Gemini/Framework/Services/IShell.cs
@@ -27,6 +27,7 @@ namespace Gemini.Framework.Services
 		IObservableCollection<IDocument> Documents { get; }
 		IObservableCollection<ITool> Tools { get; }
 
+        bool RegisterTool(ITool tool);
         void ShowTool<TTool>() where TTool : ITool;
 		void ShowTool(ITool model);
 

--- a/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
+++ b/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
@@ -193,7 +193,7 @@ namespace Gemini.Modules.Shell.Services
                         }
                     }
 
-                    shellView.LoadLayout(reader.BaseStream, t => AddTool(shell, t), d => shell.OpenDocumentAsync(d).Wait(), layoutItems);
+                    shellView.LoadLayout(reader.BaseStream, t => shell.RegisterTool(t), d => shell.OpenDocumentAsync(d).Wait(), layoutItems);
                 }
             }
             catch
@@ -202,12 +202,6 @@ namespace Gemini.Modules.Shell.Services
             }
 
             return true;
-        }
-
-        private void AddTool(IShell shell, ITool tool)
-        {
-            if (!shell.Tools.Contains(tool))
-                shell.Tools.Add(tool);
         }
     }
 }

--- a/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
+++ b/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
@@ -144,6 +144,15 @@ namespace Gemini.Modules.Shell.ViewModels
             base.OnViewLoaded(view);
         }
 
+        public bool RegisterTool(ITool tool)
+        {
+            if (Tools.Contains(tool))
+                return false;
+
+            Tools.Add(tool);
+            return true;
+        }
+
         public void ShowTool<TTool>()
             where TTool : ITool
         {
@@ -152,17 +161,12 @@ namespace Gemini.Modules.Shell.ViewModels
 
         public void ShowTool(ITool model)
         {
-            if (Tools.Contains(model))
-            {
-                model.IsVisible = true;
-            }
-            else
-            {
-                Tools.Add(model);
+            RegisterTool(model);
 
+            if (!model.IsActive)
                 model.ActivateAsync(CancellationToken.None).Wait();
-            }
 
+            model.IsVisible = true;
             model.IsSelected = true;
             ActiveLayoutItem = model;
         }


### PR DESCRIPTION
I fixed an issue on tools restored as hidden at launch but never activated at layout loading or when shown.

It's a good idea to not activate hidden tools at layout loading but we need to activate them when they are first shown in that case. `IShell.ShowTool` will now activate tools if they are not active, even if the tools was already registered in the `IShell.Tools` collection at layout loading.

I also added a `IShell.RegisterTool` method and also cleaned the Tool class implementation, especially properties setters.