### PR TITLE
Improve undo-redo

### DIFF
--- a/src/Gemini/Framework/Document.cs
+++ b/src/Gemini/Framework/Document.cs
@@ -26,10 +26,12 @@ namespace Gemini.Framework
 	    private IUndoRedoManager _undoRedoManager;
 	    public IUndoRedoManager UndoRedoManager
 	    {
-            get { return _undoRedoManager ?? (_undoRedoManager = new UndoRedoManager()); }
+            get { return _undoRedoManager ?? (_undoRedoManager = CreateUndoRedoManager()); }
 	    }
 
-		private ICommand _closeCommand;
+        protected virtual IUndoRedoManager CreateUndoRedoManager() => new UndoRedoManager();
+
+        private ICommand _closeCommand;
 		public override ICommand CloseCommand
 		{
 		    get { return _closeCommand ?? (_closeCommand = new AsyncCommand(() => TryCloseAsync(null))); }

--- a/src/Gemini/Framework/Document.cs
+++ b/src/Gemini/Framework/Document.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Caliburn.Micro;
@@ -151,5 +153,13 @@ namespace Gemini.Framework
             // Save file.
             await persistedDocument.Save(filePath);
 	    }
-	}
+
+        protected override Task OnDeactivateAsync(bool close, CancellationToken cancellationToken)
+        {
+            if (close)
+                _undoRedoManager?.Dispose();
+
+            return base.OnDeactivateAsync(close, cancellationToken);
+        }
+    }
 }

--- a/src/Gemini/Modules/UndoRedo/IUndoRedoManager.cs
+++ b/src/Gemini/Modules/UndoRedo/IUndoRedoManager.cs
@@ -4,7 +4,7 @@ using Caliburn.Micro;
 
 namespace Gemini.Modules.UndoRedo
 {
-    public interface IUndoRedoManager : INotifyPropertyChanged
+    public interface IUndoRedoManager : INotifyPropertyChanged, IDisposable
     {
         IObservableCollection<IUndoableAction> ActionStack { get; }
         IUndoableAction CurrentAction { get; }

--- a/src/Gemini/Modules/UndoRedo/IUndoRedoManager.cs
+++ b/src/Gemini/Modules/UndoRedo/IUndoRedoManager.cs
@@ -17,6 +17,7 @@ namespace Gemini.Modules.UndoRedo
         int? UndoCountLimit { get; set; }
 
         void ExecuteAction(IUndoableAction action);
+        void PushAction(IUndoableAction action);
 
         bool CanUndo { get; }
         void Undo(int actionCount);

--- a/src/Gemini/Modules/UndoRedo/Services/UndoRedoManager.cs
+++ b/src/Gemini/Modules/UndoRedo/Services/UndoRedoManager.cs
@@ -135,8 +135,12 @@ namespace Gemini.Modules.UndoRedo.Services
             if (UndoActionCount <= 0)
                 return;
 
+            OnBegin();
+
             for (var i = UndoActionCount - 1; i >= 0; i--)
                 ActionStack[i].Undo();
+
+            OnEnd();
 
             UndoActionCount = 0;
         }

--- a/src/Gemini/Modules/UndoRedo/Services/UndoRedoManager.cs
+++ b/src/Gemini/Modules/UndoRedo/Services/UndoRedoManager.cs
@@ -56,8 +56,8 @@ namespace Gemini.Modules.UndoRedo.Services
             if (removeCount <= 0)
                 return;
 
-            for (var i = 0; i < removeCount; i++)
-                ActionStack.RemoveAt(0);
+            for (var i = removeCount - 1; i >= 0; i--)
+                RemoveAction(i);
             UndoActionCount -= removeCount;
         }
         
@@ -73,7 +73,7 @@ namespace Gemini.Modules.UndoRedo.Services
             {
                 // We currently have items that can be redone, remove those
                 for (var i = ActionStack.Count - 1; i >= UndoActionCount; i--)
-                    ActionStack.RemoveAt(i);
+                    RemoveAction(i);
 
                 NotifyOfPropertyChange(() => RedoActionCount);
                 NotifyOfPropertyChange(() => CanRedo);
@@ -190,6 +190,13 @@ namespace Gemini.Modules.UndoRedo.Services
             Redo(1 + i - UndoActionCount);
         }
 
+        private void RemoveAction(int index)
+        {
+            var action = ActionStack[index];
+            ActionStack.RemoveAt(index);
+            (action as IDisposable)?.Dispose();
+        }
+
         private void OnBegin()
         {
             BatchBegin?.Invoke(this, EventArgs.Empty);
@@ -198,6 +205,12 @@ namespace Gemini.Modules.UndoRedo.Services
         private void OnEnd()
         {
             BatchEnd?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void Dispose()
+        {
+            for (var i = ActionStack.Count - 1; i >= 0; i--)
+                (ActionStack[i] as IDisposable)?.Dispose();
         }
     }
 }

--- a/src/Gemini/Modules/UndoRedo/Services/UndoRedoManager.cs
+++ b/src/Gemini/Modules/UndoRedo/Services/UndoRedoManager.cs
@@ -60,8 +60,14 @@ namespace Gemini.Modules.UndoRedo.Services
                 ActionStack.RemoveAt(0);
             UndoActionCount -= removeCount;
         }
-
+        
         public void ExecuteAction(IUndoableAction action)
+        {
+            action.Execute();
+            PushAction(action);
+        }
+
+        public void PushAction(IUndoableAction action)
         {
             if (UndoActionCount < ActionStack.Count)
             {
@@ -73,7 +79,6 @@ namespace Gemini.Modules.UndoRedo.Services
                 NotifyOfPropertyChange(() => CanRedo);
             }
 
-            action.Execute();
             ActionStack.Add(action);
             UndoActionCount++;
 

--- a/src/Gemini/Modules/UndoRedo/ViewModels/HistoryViewModel.cs
+++ b/src/Gemini/Modules/UndoRedo/ViewModels/HistoryViewModel.cs
@@ -45,15 +45,11 @@ namespace Gemini.Modules.UndoRedo.ViewModels
         private int _selectedIndex;
         public int SelectedIndex
         {
-            get { return _selectedIndex; }
+            get => _selectedIndex;
             set
             {
-                if (_selectedIndex == value)
-                    return;
-
-                _selectedIndex = value;
-                NotifyOfPropertyChange(() => SelectedIndex);
-                UndoOrRedoTo(HistoryItems[value - 1], false);
+                if (Set(ref _selectedIndex, value))
+                    UndoOrRedoTo(HistoryItems[value - 1], false);
             }
         }
 
@@ -109,9 +105,8 @@ namespace Gemini.Modules.UndoRedo.ViewModels
             switch (e.PropertyName)
             {
                 case nameof(IUndoRedoManager.UndoActionCount):
+                    Set(ref _selectedIndex, UndoRedoManager.UndoActionCount + 1, nameof(SelectedIndex));
                     RefreshItemTypes();
-                    break;
-                default:
                     break;
             }
         }

--- a/src/Gemini/Modules/UndoRedo/Views/HistoryView.xaml
+++ b/src/Gemini/Modules/UndoRedo/Views/HistoryView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Gemini.Modules.UndoRedo.Views.HistoryView"
+<UserControl x:Class="Gemini.Modules.UndoRedo.Views.HistoryView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -7,46 +7,57 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"
 			 d:DataContext="{d:DesignInstance dd:DesignTimeHistoryViewModel, IsDesignTimeCreatable=True}">
-	<Grid>
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="Auto" />
-			<ColumnDefinition Width="*" />
-		</Grid.ColumnDefinitions>
-		<Slider Grid.Column="0" Orientation="Vertical" Value="{Binding SelectedIndex}"
-				Minimum="1" Maximum="{Binding HistoryItems.Count}"
-				IsDirectionReversed="True" Margin="3 0 3 0" />
-		<ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto">
-			<ItemsControl ItemsSource="{Binding HistoryItems}">
-				<ItemsControl.ItemTemplate>
-					<DataTemplate>
-						<Border Padding="5 2 5 2" BorderBrush="{DynamicResource HistorySeparator}" BorderThickness="0 0 0 1"
-							MouseLeftButtonUp="HistoryItemMouseLeftButtonUp">
-							<Border.Style>
-								<Style TargetType="Border">
-									<Style.Triggers>
-										<DataTrigger Binding="{Binding ItemType}" Value="Current">
-											<Setter Property="Background" Value="{DynamicResource HistoryActiveBackground}" />
-										</DataTrigger>
-									</Style.Triggers>
-								</Style>
-							</Border.Style>
-							<TextBlock Text="{Binding Name}">
-								<TextBlock.Style>
-									<Style TargetType="TextBlock">
-										<Setter Property="Foreground" Value="{DynamicResource EnvironmentToolWindowDisabledText}" />
-										<Style.Triggers>
-											<DataTrigger Binding="{Binding ItemType}" Value="Redo">
-												<Setter Property="Foreground" Value="{DynamicResource EnvironmentToolWindowText}" />
-												<Setter Property="FontStyle" Value="Italic" />
-											</DataTrigger>
-										</Style.Triggers>
-									</Style>
-								</TextBlock.Style>
-							</TextBlock>
-						</Border>
-					</DataTemplate>
-				</ItemsControl.ItemTemplate>
-			</ItemsControl>
-		</ScrollViewer>
-	</Grid>
+    <Grid>
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <Grid VerticalAlignment="Top">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid Grid.Column="0"
+                      Background="{DynamicResource EnvironmentWindowBackground}">
+                    <Slider Margin="3 5"
+                            Value="{Binding SelectedIndex, Mode=TwoWay}"
+                            Minimum="1"
+                            Maximum="{Binding HistoryItems.Count}"
+                            Orientation="Vertical"
+                            IsDirectionReversed="True" />
+                </Grid>
+                <ItemsControl Grid.Column="1"
+                              ItemsSource="{Binding HistoryItems}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Padding="5 2 5 2"
+                                    BorderBrush="{DynamicResource HistorySeparator}" BorderThickness="0 0 0 1"
+                                    Background="Transparent"
+                                    MouseLeftButtonUp="HistoryItemMouseLeftButtonUp">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ItemType}" Value="Current">
+                                                <Setter Property="Background" Value="{DynamicResource HistoryActiveBackground}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <TextBlock Text="{Binding Name}" ToolTip="{Binding Name}"
+                                       TextTrimming="CharacterEllipsis">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Foreground" Value="{DynamicResource EnvironmentToolWindowText}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ItemType}" Value="Redo">
+                                                    <Setter Property="Foreground" Value="{DynamicResource EnvironmentToolWindowDisabledText}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Grid>
+        </ScrollViewer>
+    </Grid>
 </UserControl>


### PR DESCRIPTION
I made some improvements on the undo redo system:

- Allow to override a new protected method `Document.CreateUndoRedoManager` to change the implementation of `IUndoRedoManager`.
- Add method `IUndoRedoManager.PushAction` to stack an action without executing it.
    - Interesting when the first action implementation (the "do") is different from the redo, or executed before the action is stacked (for example, a painting brush draw a line continuously but push an action only when the brush is not applied anymore).
- Fix `UndoRedoManager.UndoAll` not calling `OnBegin` and `OnEnd`.
- Improve the History tool:
    - Gray text for redo actions instead of undo actions. (more intuitive to see undone actions in gray)
    - Selection synchronization fixed.
    - Slider aligned on items.
    - Text trimmed + tooltips when text is too long.

Update 23/07:
- Dispose `IUndoableAction` (if they implement IDisposable) when they are removed from undo stack. It allows to free resources kept in case the action is undone/redone.
- Dispose `IUndoRedoManager` when the document is closed to dispose all the IUndoableAction remaining in the stack.

![MkLntrpzv3](https://user-images.githubusercontent.com/7021265/175788483-3a915b6c-d88c-4344-9235-39cd200a8b1e.png)