### PR TITLE
Update to latest CM, net462, plus other nugets.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,6 +11,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.109" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/src/Gemini.Demo/Gemini.Demo.csproj
+++ b/src/Gemini.Demo/Gemini.Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
@@ -64,12 +64,16 @@
     <PackageReference Include="JeremyAnsel.HLSL.Targets" Version="1.0.9" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) != 'net461'">
+  <ItemGroup Condition="$(TargetFramework) != 'net462'">
     <PackageReference Include="HelixToolkit.Core.Wpf" Version="2.10.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net461'">
+  <ItemGroup Condition="$(TargetFramework) == 'net462'">
     <PackageReference Include="HelixToolkit.Wpf" Version="2.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.109" />
   </ItemGroup>
 
 </Project>

--- a/src/Gemini.Modules.CodeCompiler/Gemini.Modules.CodeCompiler.csproj
+++ b/src/Gemini.Modules.CodeCompiler/Gemini.Modules.CodeCompiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell C# compile Roslyn</PackageTags>
     <Description>CodeCompiler module for Gemini, providing C# code compilation using Roslyn.</Description>
   </PropertyGroup>
@@ -15,5 +15,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Gemini.Modules.CodeEditor/Gemini.Modules.CodeEditor.csproj
+++ b/src/Gemini.Modules.CodeEditor/Gemini.Modules.CodeEditor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell C# syntax highlighting AvalonEdit</PackageTags>
     <Description>CodeEditor module for Gemini, providing a syntax-highlighted code editor using AvalonEdit.</Description>

--- a/src/Gemini.Modules.ErrorList/Gemini.Modules.ErrorList.csproj
+++ b/src/Gemini.Modules.ErrorList/Gemini.Modules.ErrorList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell error list</PackageTags>
     <Description>ErrorList module for Gemini, providing a tool window to display messages, warnings and errors.</Description>

--- a/src/Gemini.Modules.GraphEditor/Gemini.Modules.GraphEditor.csproj
+++ b/src/Gemini.Modules.GraphEditor/Gemini.Modules.GraphEditor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell graph node connector connection</PackageTags>
     <Description>GraphEditor module for Gemini, providing UI controls to edit a graph of connected nodes.</Description>

--- a/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
+++ b/src/Gemini.Modules.Inspector/Gemini.Modules.Inspector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell inspector</PackageTags>
     <Description>Inspector module for Gemini, providing a flexible PropertyGrid-esque tool window.</Description>
@@ -29,6 +29,10 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Gemini.Modules.Output/Gemini.Modules.Output.csproj
+++ b/src/Gemini.Modules.Output/Gemini.Modules.Output.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell Output</PackageTags>
     <Description>Output module for Gemini, providing a buffered output tool pane.</Description>

--- a/src/Gemini.Modules.PropertyGrid/Gemini.Modules.PropertyGrid.csproj
+++ b/src/Gemini.Modules.PropertyGrid/Gemini.Modules.PropertyGrid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>core WPF MVVM AvalonDock Caliburn Micro Visual Studio IDE Shell PropertyGrid</PackageTags>
     <Description>PropertyGrid module for Gemini, utilising the PropertyGrid control from the Extended WPF Toolkit.</Description>

--- a/src/Gemini/AppBootstrapper.cs
+++ b/src/Gemini/AppBootstrapper.cs
@@ -189,10 +189,10 @@ namespace Gemini
         protected override void BuildUp(object instance)
             => Container.SatisfyImportsOnce(instance);
 
-        protected override void OnStartup(object sender, StartupEventArgs e)
+        protected override async void OnStartup(object sender, StartupEventArgs e)
         {
             base.OnStartup(sender, e);
-            DisplayRootViewFor<IMainWindow>();
+            await DisplayRootViewForAsync<IMainWindow>();
         }
 
         protected override IEnumerable<Assembly> SelectAssemblies()

--- a/src/Gemini/AppBootstrapper.cs
+++ b/src/Gemini/AppBootstrapper.cs
@@ -189,10 +189,10 @@ namespace Gemini
         protected override void BuildUp(object instance)
             => Container.SatisfyImportsOnce(instance);
 
-        protected override async void OnStartup(object sender, StartupEventArgs e)
+        protected override void OnStartup(object sender, StartupEventArgs e)
         {
             base.OnStartup(sender, e);
-            await DisplayRootViewForAsync<IMainWindow>();
+            DisplayRootViewForAsync<IMainWindow>();
         }
 
         protected override IEnumerable<Assembly> SelectAssemblies()

--- a/src/Gemini/Gemini.csproj
+++ b/src/Gemini/Gemini.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageId>GeminiWpf</PackageId>
     <Title>Gemini</Title>
@@ -9,7 +9,7 @@
     <Description>Gemini is an application shell similar in concept to the Visual Studio Shell. It uses AvalonDock and has an MVVM architecture based on Caliburn Micro.</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net461'">
+  <ItemGroup Condition="$(TargetFramework) == 'net462'">
     <Reference Include="PresentationFramework.Aero" />
   </ItemGroup>
 
@@ -52,11 +52,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.173" />
+    <PackageReference Include="Caliburn.Micro" Version="4.0.210" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.60.0" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="4.6.78" />
-    <PackageReference Include="MahApps.Metro" Version="2.0.0-alpha0660" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" Condition="$(TargetFramework) == 'net461'" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.9" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
   </ItemGroup>
   
 </Project>

--- a/src/Gemini/Gemini.csproj
+++ b/src/Gemini/Gemini.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageId>GeminiWpf</PackageId>
     <Title>Gemini</Title>
@@ -9,7 +9,7 @@
     <Description>Gemini is an application shell similar in concept to the Visual Studio Shell. It uses AvalonDock and has an MVVM architecture based on Caliburn Micro.</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net461'">
+  <ItemGroup Condition="$(TargetFramework) == 'net462'">
     <Reference Include="PresentationFramework.Aero" />
   </ItemGroup>
 
@@ -52,11 +52,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Caliburn.Micro" Version="4.0.173" />
+    <PackageReference Include="Caliburn.Micro" Version="4.0.210" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="3.6.2" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="4.6.78" />
-    <PackageReference Include="MahApps.Metro" Version="2.0.0-alpha0660" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" Condition="$(TargetFramework) == 'net461'" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.9" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Move minimum .NET version from 461 to 462, required for Caliburn Micro 4.0.210.
Update Caliburn.Micro to 4.0.210.
Update MahApps.Metro to 2.4.9.
Update System.ComponentModel.Composition to 6.0.0.
Update Nerdbank.Gitversioning to 3.5.109.

Fix AppBootstrapper.OnStartup to use DisplayRootViewForAsync, as the synchronous API was removed last year.

Add System.Drawing.Common v6 reference to Inspector module to address issues with ScreenShotUtility using the Bitmap type. See: https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.