### PR TITLE
PR #328 ActivateAsync regression fix

### DIFF
--- a/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
+++ b/src/Gemini/Modules/Shell/Services/LayoutItemStatePersister.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Caliburn.Micro;
 using Gemini.Framework;
 using Gemini.Framework.Services;
@@ -193,7 +194,10 @@ namespace Gemini.Modules.Shell.Services
                         }
                     }
 
-                    shellView.LoadLayout(reader.BaseStream, t => AddTool(shell, t), d => shell.OpenDocumentAsync(d).Wait(), layoutItems);
+                    shellView.LoadLayout(reader.BaseStream,
+                        t => AddTool(shell, t),
+                        d => shell.OpenDocumentAsync(d).Wait(),
+                        layoutItems);
                 }
             }
             catch
@@ -204,10 +208,16 @@ namespace Gemini.Modules.Shell.Services
             return true;
         }
 
+        // This needs to keep behavior with Gemini.Modules.Shell.ViewModels.ShellViewModel.ShowTool
+        // which calls ActivateAsync
         private void AddTool(IShell shell, ITool tool)
         {
             if (!shell.Tools.Contains(tool))
+            {
                 shell.Tools.Add(tool);
+
+                tool.ActivateAsync(CancellationToken.None).Wait();
+            }
         }
     }
 }

--- a/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
+++ b/src/Gemini/Modules/Shell/ViewModels/ShellViewModel.cs
@@ -158,6 +158,8 @@ namespace Gemini.Modules.Shell.ViewModels
             }
             else
             {
+                // This logic is duplicated in Gemini.Modules.Shell.Services.LayoutItemStatePersister.AddTool
+
                 Tools.Add(model);
 
                 model.ActivateAsync(CancellationToken.None).Wait();


### PR DESCRIPTION
Fix LayoutItemStatePersister.LoadState so that it has matching behavior with ShellViewModel.OnViewLoaded. This is due to aa7a8b5557a716f6e3027e46b904c53f80b2e46b (from a PR #318 that I originally made) adding support for calling a Tool's ActivateAsync on the first showing.

This was broken by 60ede6456f2048f77966d899945dc1cc433aa6bf in PR #328.