### PR TITLE
Dynamic Menu item exclusion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,13 +459,13 @@ menus in the same way.
 public static class MenuDefinitions
 {
     [Export]
-    public static MenuDefinition FileMenu = new MenuDefinition(MainMenuBar, 0, Resources.FileMenuText);
+    public static readonly MenuDefinition FileMenu = new MenuDefinition(MainMenuBar, 0, Resources.FileMenuText);
 	
 	[Export]
-    public static MenuItemGroupDefinition FileNewOpenMenuGroup = new MenuItemGroupDefinition(FileMenu, 0);
+    public static readonly MenuItemGroupDefinition FileNewOpenMenuGroup = new MenuItemGroupDefinition(FileMenu, 0);
 	
 	[Export]
-    public static MenuItemDefinition FileNewMenuItem = new TextMenuItemDefinition(
+    public static readonly MenuItemDefinition FileNewMenuItem = new TextMenuItemDefinition(
         MenuDefinitions.FileNewOpenMenuGroup, 0, "_New");
 }
 ```
@@ -476,13 +476,13 @@ To remove an existing menu item (such as a built-in menu item that you don't wan
 
 ``` csharp
 [Export]
-public static ExcludeMenuItemDefinition ExcludeOpenMenuItem = new ExcludeMenuItemDefinition(Gemini.Modules.Shell.MenuDefinitions.FileOpenMenuItem);
+public static readonly ExcludeMenuItemDefinition ExcludeOpenMenuItem = new ExcludeMenuItemDefinition(Gemini.Modules.Shell.MenuDefinitions.FileOpenMenuItem);
 
 [Export]
-public static ExcludeMenuItemGroupDefinition ExcludeWindowMenuItemGroup = new ExcludeMenuItemGroupDefinition(Gemini.Modules.MainMenu.MenuDefinitions.ViewToolsMenuGroup);
+public static readonly ExcludeMenuItemGroupDefinition ExcludeWindowMenuItemGroup = new ExcludeMenuItemGroupDefinition(Gemini.Modules.MainMenu.MenuDefinitions.ViewToolsMenuGroup);
 
 [Export]
-public static ExcludeMenuDefinition ExcludeWindowMenuDefinition = new ExcludeMenuDefinition(Gemini.Modules.MainMenu.MenuDefinitions.WindowMenu);
+public static readonly ExcludeMenuDefinition ExcludeWindowMenuDefinition = new ExcludeMenuDefinition(Gemini.Modules.MainMenu.MenuDefinitions.WindowMenu);
 ```
 
 ### StatusBar module

--- a/src/Gemini.Demo/Modules/FilterDesigner/MenuDefinitions.cs
+++ b/src/Gemini.Demo/Modules/FilterDesigner/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Demo.Modules.FilterDesigner.Commands;
 using Gemini.Framework.Menus;
 
@@ -7,7 +7,7 @@ namespace Gemini.Demo.Modules.FilterDesigner
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition OpenGraphMenuItem = new CommandMenuItemDefinition<OpenGraphCommandDefinition>(
+        public static readonly MenuItemDefinition OpenGraphMenuItem = new CommandMenuItemDefinition<OpenGraphCommandDefinition>(
             Gemini.Modules.MainMenu.MenuDefinitions.FileNewOpenMenuGroup, 2);
     }
 }

--- a/src/Gemini.Demo/Modules/Home/Module.cs
+++ b/src/Gemini.Demo/Modules/Home/Module.cs
@@ -10,34 +10,55 @@ using Gemini.Modules.PropertyGrid;
 
 namespace Gemini.Demo.Modules.Home
 {
-	[Export(typeof(IModule))]
-	public class Module : ModuleBase
-	{
+    [Export(typeof(IModule))]
+    public class Module : ModuleBase
+    {
         [Export]
-        public static MenuItemGroupDefinition ViewDemoMenuGroup = new MenuItemGroupDefinition(
+        public static readonly MenuItemGroupDefinition ViewDemoMenuGroup = new MenuItemGroupDefinition(
             Gemini.Modules.MainMenu.MenuDefinitions.ViewMenu, 10);
 
         [Export]
-	    public static MenuItemDefinition ViewHomeMenuItem = new CommandMenuItemDefinition<ViewHomeCommandDefinition>(
+        public static readonly MenuItemDefinition ViewHomeMenuItem = new CommandMenuItemDefinition<ViewHomeCommandDefinition>(
             ViewDemoMenuGroup, 0);
 
         [Export]
-        public static MenuItemDefinition ViewHelixMenuItem = new CommandMenuItemDefinition<ViewHelixCommandDefinition>(
+        public static readonly MenuItemDefinition ViewHelixMenuItem = new CommandMenuItemDefinition<ViewHelixCommandDefinition>(
             ViewDemoMenuGroup, 1);
 
-	    public override IEnumerable<IDocument> DefaultDocuments
-	    {
-	        get
-	        {
+        #region Debug menu
+        [Export]
+        public static readonly MenuDefinition DebugMenu = new MenuDefinition(
+            Gemini.Modules.MainMenu.MenuDefinitions.MainMenuBar,
+            int.MaxValue,
+            "DEBUG")
+            // Exclude this menu when there is no debugger attached AT STARTUP.
+            // This predicate isn't re-evaluated after menus are built (unless rebuild functionality gets added)
+            .SetDynamicExclusionPredicate(_ => System.Diagnostics.Debugger.IsAttached==false);
+
+        [Export]
+        public static readonly MenuItemGroupDefinition DebugMenuGroup = new MenuItemGroupDefinition(
+            DebugMenu, 1);
+
+        // You should NOT see this item when there unless a debugger was attached during startup
+        [Export]
+        public static readonly MenuItemDefinition DebugTestMenu = new TextMenuItemDefinition(
+            DebugMenuGroup, 0,
+            "Debugger.IsAttached=true");
+        #endregion
+
+        public override IEnumerable<IDocument> DefaultDocuments
+        {
+            get
+            {
                 yield return IoC.Get<HomeViewModel>();
                 yield return IoC.Get<HelixViewModel>();
-	        }
-	    }
+            }
+        }
 
         public override async Task PostInitializeAsync()
         {
             IoC.Get<IPropertyGrid>().SelectedObject = IoC.Get<HomeViewModel>();
             await Shell.OpenDocumentAsync(IoC.Get<HomeViewModel>());
         }
-	}
+    }
 }

--- a/src/Gemini.Modules.ErrorList/MenuDefinitions.cs
+++ b/src/Gemini.Modules.ErrorList/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Modules.ErrorList.Commands;
 
@@ -7,7 +7,7 @@ namespace Gemini.Modules.ErrorList
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition ViewErrorListMenuItem = new CommandMenuItemDefinition<ViewErrorListCommandDefinition>(
+        public static readonly MenuItemDefinition ViewErrorListMenuItem = new CommandMenuItemDefinition<ViewErrorListCommandDefinition>(
             MainMenu.MenuDefinitions.ViewToolsMenuGroup, 0);
     }
 }

--- a/src/Gemini.Modules.Inspector/MenuDefinitions.cs
+++ b/src/Gemini.Modules.Inspector/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Modules.Inspector.Commands;
 
@@ -7,7 +7,7 @@ namespace Gemini.Modules.Inspector
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition ViewInspectorMenuItem = new CommandMenuItemDefinition<ViewInspectorCommandDefinition>(
+        public static readonly MenuItemDefinition ViewInspectorMenuItem = new CommandMenuItemDefinition<ViewInspectorCommandDefinition>(
             MainMenu.MenuDefinitions.ViewPropertiesMenuGroup, 1);
     }
 }

--- a/src/Gemini.Modules.Output/MenuDefinitions.cs
+++ b/src/Gemini.Modules.Output/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Modules.Output.Commands;
 
@@ -7,7 +7,7 @@ namespace Gemini.Modules.Output
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition ViewOutputMenuItem = new CommandMenuItemDefinition<ViewOutputCommandDefinition>(
+        public static readonly MenuItemDefinition ViewOutputMenuItem = new CommandMenuItemDefinition<ViewOutputCommandDefinition>(
             MainMenu.MenuDefinitions.ViewToolsMenuGroup, 1);
     }
 }

--- a/src/Gemini.Modules.PropertyGrid/MenuDefinitions.cs
+++ b/src/Gemini.Modules.PropertyGrid/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Modules.PropertyGrid.Commands;
 
@@ -7,7 +7,7 @@ namespace Gemini.Modules.PropertyGrid
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition ViewPropertyGridMenuItem = new CommandMenuItemDefinition<ViewPropertyGridCommandDefinition>(
+        public static readonly MenuItemDefinition ViewPropertyGridMenuItem = new CommandMenuItemDefinition<ViewPropertyGridCommandDefinition>(
             MainMenu.MenuDefinitions.ViewPropertiesMenuGroup, 0);
     }
 }

--- a/src/Gemini/Framework/Menus/CommandMenuItemDefinition.cs
+++ b/src/Gemini/Framework/Menus/CommandMenuItemDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 using Caliburn.Micro;
 using Gemini.Framework.Commands;
@@ -11,25 +11,13 @@ namespace Gemini.Framework.Menus
         private readonly CommandDefinitionBase _commandDefinition;
         private readonly KeyGesture _keyGesture;
 
-        public override string Text
-        {
-            get { return _commandDefinition.Text; }
-        }
+        public override string Text => _commandDefinition.Text;
 
-        public override Uri IconSource
-        {
-            get { return _commandDefinition.IconSource; }
-        }
+        public override Uri IconSource => _commandDefinition.IconSource;
 
-        public override KeyGesture KeyGesture
-        {
-            get { return _keyGesture; }
-        }
+        public override KeyGesture KeyGesture => _keyGesture;
 
-        public override CommandDefinitionBase CommandDefinition
-        {
-            get { return _commandDefinition; }
-        }
+        public override CommandDefinitionBase CommandDefinition => _commandDefinition;
 
         public CommandMenuItemDefinition(MenuItemGroupDefinition group, int sortOrder)
             : base(group, sortOrder)

--- a/src/Gemini/Framework/Menus/ExcludeMenuDefinition.cs
+++ b/src/Gemini/Framework/Menus/ExcludeMenuDefinition.cs
@@ -1,16 +1,13 @@
-﻿namespace Gemini.Framework.Menus
+namespace Gemini.Framework.Menus
 {
+    [System.Diagnostics.DebuggerDisplay("Exclude {MenuDefinitionToExclude}")]
     public class ExcludeMenuDefinition
     {
-        private readonly MenuDefinition _menuDefinitionToExclude;
-        public MenuDefinition MenuDefinitionToExclude 
-        { 
-            get { return _menuDefinitionToExclude; } 
-        }
+        public MenuDefinition MenuDefinitionToExclude { get; private set; }
 
         public ExcludeMenuDefinition(MenuDefinition menuDefinition)
         {
-            _menuDefinitionToExclude = menuDefinition;
+            MenuDefinitionToExclude = menuDefinition;
         }
     }
 }

--- a/src/Gemini/Framework/Menus/ExcludeMenuItemDefinition.cs
+++ b/src/Gemini/Framework/Menus/ExcludeMenuItemDefinition.cs
@@ -1,16 +1,13 @@
-﻿namespace Gemini.Framework.Menus
+namespace Gemini.Framework.Menus
 {
+    [System.Diagnostics.DebuggerDisplay("Exclude {MenuItemDefinitionToExclude}")]
     public class ExcludeMenuItemDefinition
     {
-        private readonly MenuItemDefinition _menuItemDefinitionToExclude;
-        public MenuItemDefinition MenuItemDefinitionToExclude 
-        { 
-            get { return _menuItemDefinitionToExclude; } 
-        }
+        public MenuItemDefinition MenuItemDefinitionToExclude { get; private set; }
 
         public ExcludeMenuItemDefinition(MenuItemDefinition menuItemDefinition)
         {
-            _menuItemDefinitionToExclude = menuItemDefinition;
+            MenuItemDefinitionToExclude = menuItemDefinition;
         }
     }
 }

--- a/src/Gemini/Framework/Menus/ExcludeMenuItemGroupDefinition.cs
+++ b/src/Gemini/Framework/Menus/ExcludeMenuItemGroupDefinition.cs
@@ -1,16 +1,13 @@
-﻿namespace Gemini.Framework.Menus
+namespace Gemini.Framework.Menus
 {
+    [System.Diagnostics.DebuggerDisplay("Exclude {MenuItemGroupDefinitionToExclude}")]
     public class ExcludeMenuItemGroupDefinition
     {
-        private readonly MenuItemGroupDefinition _menuItemGroupDefinitionToExclude;
-        public MenuItemGroupDefinition MenuItemGroupDefinitionToExclude 
-        {
-            get { return _menuItemGroupDefinitionToExclude; }
-        }
+        public MenuItemGroupDefinition MenuItemGroupDefinitionToExclude { get; private set; }
 
         public ExcludeMenuItemGroupDefinition(MenuItemGroupDefinition menuItemGroupDefinition)
         {
-            _menuItemGroupDefinitionToExclude = menuItemGroupDefinition;
+            MenuItemGroupDefinitionToExclude = menuItemGroupDefinition;
         }
     }
 }

--- a/src/Gemini/Framework/Menus/MenuDefinition.cs
+++ b/src/Gemini/Framework/Menus/MenuDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 using Gemini.Framework.Commands;
 
@@ -6,45 +6,33 @@ namespace Gemini.Framework.Menus
 {
     public class MenuDefinition : MenuDefinitionBase
     {
-        private readonly MenuBarDefinition _menuBar;
         private readonly int _sortOrder;
         private readonly string _text;
 
-        public MenuBarDefinition MenuBar
-        {
-            get { return _menuBar; }
-        }
+        public MenuBarDefinition MenuBar { get; private set; }
 
-        public override int SortOrder
-        {
-            get { return _sortOrder; }
-        }
+        public override int SortOrder => _sortOrder;
 
-        public override string Text
-        {
-            get { return _text; }
-        }
+        public override string Text => _text;
 
-        public override Uri IconSource
-        {
-            get { return null; }
-        }
+        public override Uri IconSource => null;
 
-        public override KeyGesture KeyGesture
-        {
-            get { return null; }
-        }
+        public override KeyGesture KeyGesture => null;
 
-        public override CommandDefinitionBase CommandDefinition
-        {
-            get { return null; }
-        }
+        public override CommandDefinitionBase CommandDefinition => null;
 
         public MenuDefinition(MenuBarDefinition menuBar, int sortOrder, string text)
         {
-            _menuBar = menuBar;
+            MenuBar = menuBar;
             _sortOrder = sortOrder;
             _text = text;
+        }
+
+        public MenuDefinition SetDynamicExclusionPredicate(
+            Predicate<MenuDefinitionBase> predicate)
+        {
+            DynamicExclusionPredicate = predicate;
+            return this;
         }
     }
 }

--- a/src/Gemini/Framework/Menus/MenuDefinitionBase.cs
+++ b/src/Gemini/Framework/Menus/MenuDefinitionBase.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 using Gemini.Framework.Commands;
 
 namespace Gemini.Framework.Menus
 {
+    [System.Diagnostics.DebuggerDisplay("{Text}")]
     public abstract class MenuDefinitionBase
     {
         public abstract int SortOrder { get; }
@@ -11,5 +12,12 @@ namespace Gemini.Framework.Menus
         public abstract Uri IconSource { get; }
         public abstract KeyGesture KeyGesture { get; }
         public abstract CommandDefinitionBase CommandDefinition { get; }
+
+        /// <summary>
+        /// An optional predicate which is called using this instance,
+        /// which when it returns true, informs that the menu should be
+        /// excluded from view
+        /// </summary>
+        public Predicate<MenuDefinitionBase> DynamicExclusionPredicate { get; protected set; }
     }
 }

--- a/src/Gemini/Framework/Menus/MenuItemDefinition.cs
+++ b/src/Gemini/Framework/Menus/MenuItemDefinition.cs
@@ -1,24 +1,26 @@
-﻿namespace Gemini.Framework.Menus
+using System;
+
+namespace Gemini.Framework.Menus
 {
     public abstract class MenuItemDefinition : MenuDefinitionBase
     {
-        private readonly MenuItemGroupDefinition _group;
         private readonly int _sortOrder;
 
-        public MenuItemGroupDefinition Group
-        {
-            get { return _group; }
-        }
+        public MenuItemGroupDefinition Group { get; private set; }
 
-        public override int SortOrder
-        {
-            get { return _sortOrder; }
-        }
+        public override int SortOrder => _sortOrder;
 
         protected MenuItemDefinition(MenuItemGroupDefinition group, int sortOrder)
         {
-            _group = group;
+            Group = group;
             _sortOrder = sortOrder;
+        }
+
+        public MenuItemDefinition SetDynamicExclusionPredicate(
+            Predicate<MenuDefinitionBase> predicate)
+        {
+            DynamicExclusionPredicate = predicate;
+            return this;
         }
     }
 }

--- a/src/Gemini/Framework/Menus/MenuItemGroupDefinition.cs
+++ b/src/Gemini/Framework/Menus/MenuItemGroupDefinition.cs
@@ -1,24 +1,33 @@
-﻿namespace Gemini.Framework.Menus
+using System;
+
+namespace Gemini.Framework.Menus
 {
     public class MenuItemGroupDefinition
     {
-        private readonly MenuDefinitionBase _parent;
         private readonly int _sortOrder;
 
-        public MenuDefinitionBase Parent
-        {
-            get { return _parent; }
-        }
+        public MenuDefinitionBase Parent { get; private set; }
 
-        public int SortOrder
-        {
-            get { return _sortOrder; }
-        }
+        public int SortOrder => _sortOrder;
 
         public MenuItemGroupDefinition(MenuDefinitionBase parent, int sortOrder)
         {
-            _parent = parent;
+            Parent = parent;
             _sortOrder = sortOrder;
+        }
+
+        /// <summary>
+        /// An optional predicate which is called using this instance,
+        /// which when it returns true, informs that the menu should be
+        /// excluded from view
+        /// </summary>
+        public Predicate<MenuItemGroupDefinition> DynamicExclusionPredicate { get; protected set; }
+
+        public MenuItemGroupDefinition SetDynamicExclusionPredicate(
+            Predicate<MenuItemGroupDefinition> predicate)
+        {
+            DynamicExclusionPredicate = predicate;
+            return this;
         }
     }
 }

--- a/src/Gemini/Framework/Menus/TextMenuItemDefinition.cs
+++ b/src/Gemini/Framework/Menus/TextMenuItemDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Input;
 using Gemini.Framework.Commands;
 
@@ -9,25 +9,13 @@ namespace Gemini.Framework.Menus
         private readonly string _text;
         private readonly Uri _iconSource;
 
-        public override string Text
-        {
-            get { return _text; }
-        }
+        public override string Text => _text;
 
-        public override Uri IconSource
-        {
-            get { return _iconSource; }
-        }
+        public override Uri IconSource => _iconSource;
 
-        public override KeyGesture KeyGesture
-        {
-            get { return null; }
-        }
+        public override KeyGesture KeyGesture => null;
 
-        public override CommandDefinitionBase CommandDefinition
-        {
-            get { return null; }
-        }
+        public override CommandDefinitionBase CommandDefinition => null;
 
         public TextMenuItemDefinition(MenuItemGroupDefinition group, int sortOrder, string text, Uri iconSource = null)
             : base(group, sortOrder)

--- a/src/Gemini/Modules/MainMenu/MenuDefinitions.cs
+++ b/src/Gemini/Modules/MainMenu/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Properties;
 
@@ -7,51 +7,51 @@ namespace Gemini.Modules.MainMenu
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuBarDefinition MainMenuBar = new MenuBarDefinition();
+        public static readonly MenuBarDefinition MainMenuBar = new MenuBarDefinition();
 
         [Export]
-        public static MenuDefinition FileMenu = new MenuDefinition(MainMenuBar, 0, Resources.FileMenuText);
+        public static readonly MenuDefinition FileMenu = new MenuDefinition(MainMenuBar, 0, Resources.FileMenuText);
 
         [Export]
-        public static MenuItemGroupDefinition FileNewOpenMenuGroup = new MenuItemGroupDefinition(FileMenu, 0);
+        public static readonly MenuItemGroupDefinition FileNewOpenMenuGroup = new MenuItemGroupDefinition(FileMenu, 0);
 
         [Export]
-        public static MenuItemGroupDefinition FileCloseMenuGroup = new MenuItemGroupDefinition(FileMenu, 3);
+        public static readonly MenuItemGroupDefinition FileCloseMenuGroup = new MenuItemGroupDefinition(FileMenu, 3);
 
         [Export]
-        public static MenuItemGroupDefinition FileSaveMenuGroup = new MenuItemGroupDefinition(FileMenu, 6);
+        public static readonly MenuItemGroupDefinition FileSaveMenuGroup = new MenuItemGroupDefinition(FileMenu, 6);
 
         [Export]
-        public static MenuItemGroupDefinition FileExitOpenMenuGroup = new MenuItemGroupDefinition(FileMenu, 10);
+        public static readonly MenuItemGroupDefinition FileExitOpenMenuGroup = new MenuItemGroupDefinition(FileMenu, 10);
 
         [Export]
-        public static MenuDefinition EditMenu = new MenuDefinition(MainMenuBar, 1, Resources.EditMenuText);
+        public static readonly MenuDefinition EditMenu = new MenuDefinition(MainMenuBar, 1, Resources.EditMenuText);
 
         [Export]
-        public static MenuItemGroupDefinition EditUndoRedoMenuGroup = new MenuItemGroupDefinition(EditMenu, 0);
+        public static readonly MenuItemGroupDefinition EditUndoRedoMenuGroup = new MenuItemGroupDefinition(EditMenu, 0);
 
         [Export]
-        public static MenuDefinition ViewMenu = new MenuDefinition(MainMenuBar, 2, Resources.ViewMenuText);
+        public static readonly MenuDefinition ViewMenu = new MenuDefinition(MainMenuBar, 2, Resources.ViewMenuText);
 
         [Export]
-        public static MenuItemGroupDefinition ViewToolsMenuGroup = new MenuItemGroupDefinition(ViewMenu, 0);
+        public static readonly MenuItemGroupDefinition ViewToolsMenuGroup = new MenuItemGroupDefinition(ViewMenu, 0);
 
         [Export]
-        public static MenuItemGroupDefinition ViewPropertiesMenuGroup = new MenuItemGroupDefinition(ViewMenu, 100);
+        public static readonly MenuItemGroupDefinition ViewPropertiesMenuGroup = new MenuItemGroupDefinition(ViewMenu, 100);
 
         [Export]
-        public static MenuDefinition ToolsMenu = new MenuDefinition(MainMenuBar, 10, Resources.ToolsMenuText);
+        public static readonly MenuDefinition ToolsMenu = new MenuDefinition(MainMenuBar, 10, Resources.ToolsMenuText);
 
         [Export]
-        public static MenuItemGroupDefinition ToolsOptionsMenuGroup = new MenuItemGroupDefinition(ToolsMenu, 100);
+        public static readonly MenuItemGroupDefinition ToolsOptionsMenuGroup = new MenuItemGroupDefinition(ToolsMenu, 100);
 
         [Export]
-        public static MenuDefinition WindowMenu = new MenuDefinition(MainMenuBar, 20, Resources.WindowMenuText);
+        public static readonly MenuDefinition WindowMenu = new MenuDefinition(MainMenuBar, 20, Resources.WindowMenuText);
 
         [Export]
-        public static MenuItemGroupDefinition WindowDocumentListMenuGroup = new MenuItemGroupDefinition(WindowMenu, 10);
+        public static readonly MenuItemGroupDefinition WindowDocumentListMenuGroup = new MenuItemGroupDefinition(WindowMenu, 10);
 
         [Export]
-        public static MenuDefinition HelpMenu = new MenuDefinition(MainMenuBar, 30, Resources.HelpMenuText);
+        public static readonly MenuDefinition HelpMenu = new MenuDefinition(MainMenuBar, 30, Resources.HelpMenuText);
     }
 }

--- a/src/Gemini/Modules/MainMenu/Models/MenuItemBase.cs
+++ b/src/Gemini/Modules/MainMenu/Models/MenuItemBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using Caliburn.Micro;
 
@@ -6,43 +6,34 @@ namespace Gemini.Modules.MainMenu.Models
 {
 	public class MenuItemBase : PropertyChangedBase, IEnumerable<MenuItemBase>
 	{
-		#region Static stuff
+        #region Static stuff
 
-		public static MenuItemBase Separator
+        public static MenuItemBase Separator => new MenuItemSeparator();
+
+        #endregion
+
+        #region Properties
+
+        public IObservableCollection<MenuItemBase> Children { get; private set; }
+            = new BindableCollection<MenuItemBase>();
+
+        #endregion
+
+        #region Constructors
+
+        protected MenuItemBase()
 		{
-			get { return new MenuItemSeparator(); }
 		}
 
-		#endregion
+        #endregion
 
-		#region Properties
+        public void Add(params MenuItemBase[] menuItems)
+            => menuItems.Apply(Children.Add);
 
-		public IObservableCollection<MenuItemBase> Children { get; private set; }
+        public IEnumerator<MenuItemBase> GetEnumerator()
+            => Children.GetEnumerator();
 
-	    #endregion
-
-		#region Constructors
-
-		protected MenuItemBase()
-		{
-			Children = new BindableCollection<MenuItemBase>();
-		}
-
-		#endregion
-
-		public void Add(params MenuItemBase[] menuItems)
-		{
-			menuItems.Apply(Children.Add);
-		}
-
-		public IEnumerator<MenuItemBase> GetEnumerator()
-		{
-			return Children.GetEnumerator();
-		}
-
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return GetEnumerator();
-		}
-	}
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+    }
 }

--- a/src/Gemini/Modules/Settings/MenuDefinitions.cs
+++ b/src/Gemini/Modules/Settings/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Modules.Settings.Commands;
 
@@ -7,7 +7,7 @@ namespace Gemini.Modules.Settings
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition OpenSettingsMenuItem = new CommandMenuItemDefinition<OpenSettingsCommandDefinition>(
+        public static readonly MenuItemDefinition OpenSettingsMenuItem = new CommandMenuItemDefinition<OpenSettingsCommandDefinition>(
             MainMenu.MenuDefinitions.ToolsOptionsMenuGroup, 0);
     }
 }

--- a/src/Gemini/Modules/Shell/MenuDefinitions.cs
+++ b/src/Gemini/Modules/Shell/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Modules.Shell.Commands;
 using Gemini.Properties;
@@ -8,47 +8,47 @@ namespace Gemini.Modules.Shell
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition FileNewMenuItem = new TextMenuItemDefinition(
+        public static readonly MenuItemDefinition FileNewMenuItem = new TextMenuItemDefinition(
             MainMenu.MenuDefinitions.FileNewOpenMenuGroup, 0, Resources.FileNewCommandText);
 
         [Export]
-        public static MenuItemGroupDefinition FileNewCascadeGroup = new MenuItemGroupDefinition(
+        public static readonly MenuItemGroupDefinition FileNewCascadeGroup = new MenuItemGroupDefinition(
             FileNewMenuItem, 0);
 
         [Export]
-        public static MenuItemDefinition FileNewMenuItemList = new CommandMenuItemDefinition<NewFileCommandListDefinition>(
+        public static readonly MenuItemDefinition FileNewMenuItemList = new CommandMenuItemDefinition<NewFileCommandListDefinition>(
             FileNewCascadeGroup, 0);
 
         [Export]
-        public static MenuItemDefinition FileOpenMenuItem = new CommandMenuItemDefinition<OpenFileCommandDefinition>(
+        public static readonly MenuItemDefinition FileOpenMenuItem = new CommandMenuItemDefinition<OpenFileCommandDefinition>(
             MainMenu.MenuDefinitions.FileNewOpenMenuGroup, 1);
 
         [Export]
-        public static MenuItemDefinition FileCloseMenuItem = new CommandMenuItemDefinition<CloseFileCommandDefinition>(
+        public static readonly MenuItemDefinition FileCloseMenuItem = new CommandMenuItemDefinition<CloseFileCommandDefinition>(
             MainMenu.MenuDefinitions.FileCloseMenuGroup, 0);
 
         [Export]
-        public static MenuItemDefinition FileSaveMenuItem = new CommandMenuItemDefinition<SaveFileCommandDefinition>(
+        public static readonly MenuItemDefinition FileSaveMenuItem = new CommandMenuItemDefinition<SaveFileCommandDefinition>(
             MainMenu.MenuDefinitions.FileSaveMenuGroup, 0);
 
         [Export]
-        public static MenuItemDefinition FileSaveAsMenuItem = new CommandMenuItemDefinition<SaveFileAsCommandDefinition>(
+        public static readonly MenuItemDefinition FileSaveAsMenuItem = new CommandMenuItemDefinition<SaveFileAsCommandDefinition>(
             MainMenu.MenuDefinitions.FileSaveMenuGroup, 1);
 
         [Export]
-        public static MenuItemDefinition FileSaveAllMenuItem = new CommandMenuItemDefinition<SaveAllFilesCommandDefinition>(
+        public static readonly MenuItemDefinition FileSaveAllMenuItem = new CommandMenuItemDefinition<SaveAllFilesCommandDefinition>(
             MainMenu.MenuDefinitions.FileSaveMenuGroup, 1);
 
         [Export]
-        public static MenuItemDefinition FileExitMenuItem = new CommandMenuItemDefinition<ExitCommandDefinition>(
+        public static readonly MenuItemDefinition FileExitMenuItem = new CommandMenuItemDefinition<ExitCommandDefinition>(
             MainMenu.MenuDefinitions.FileExitOpenMenuGroup, 0);
 
         [Export]
-        public static MenuItemDefinition WindowDocumentList = new CommandMenuItemDefinition<SwitchToDocumentCommandListDefinition>(
+        public static readonly MenuItemDefinition WindowDocumentList = new CommandMenuItemDefinition<SwitchToDocumentCommandListDefinition>(
             MainMenu.MenuDefinitions.WindowDocumentListMenuGroup, 0);
 
         [Export]
-        public static MenuItemDefinition ViewFullscreenItem = new CommandMenuItemDefinition<ViewFullScreenCommandDefinition>(
+        public static readonly MenuItemDefinition ViewFullscreenItem = new CommandMenuItemDefinition<ViewFullScreenCommandDefinition>(
             MainMenu.MenuDefinitions.ViewPropertiesMenuGroup, 0);
     }
 }

--- a/src/Gemini/Modules/Toolbox/MenuDefinitions.cs
+++ b/src/Gemini/Modules/Toolbox/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Modules.Toolbox.Commands;
 
@@ -7,7 +7,7 @@ namespace Gemini.Modules.Toolbox
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition ViewToolboxMenuItem = new CommandMenuItemDefinition<ViewToolboxCommandDefinition>(
+        public static readonly MenuItemDefinition ViewToolboxMenuItem = new CommandMenuItemDefinition<ViewToolboxCommandDefinition>(
             MainMenu.MenuDefinitions.ViewToolsMenuGroup, 4);
     }
 }

--- a/src/Gemini/Modules/UndoRedo/MenuDefinitions.cs
+++ b/src/Gemini/Modules/UndoRedo/MenuDefinitions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using Gemini.Framework.Menus;
 using Gemini.Modules.UndoRedo.Commands;
 
@@ -7,15 +7,15 @@ namespace Gemini.Modules.UndoRedo
     public static class MenuDefinitions
     {
         [Export]
-        public static MenuItemDefinition EditUndoMenuItem = new CommandMenuItemDefinition<UndoCommandDefinition>(
+        public static readonly MenuItemDefinition EditUndoMenuItem = new CommandMenuItemDefinition<UndoCommandDefinition>(
             MainMenu.MenuDefinitions.EditUndoRedoMenuGroup, 0);
 
         [Export]
-        public static MenuItemDefinition EditRedoMenuItem = new CommandMenuItemDefinition<RedoCommandDefinition>(
+        public static readonly MenuItemDefinition EditRedoMenuItem = new CommandMenuItemDefinition<RedoCommandDefinition>(
             MainMenu.MenuDefinitions.EditUndoRedoMenuGroup, 1);
 
         [Export]
-        public static MenuItemDefinition ViewHistoryMenuItem = new CommandMenuItemDefinition<ViewHistoryCommandDefinition>(
+        public static readonly MenuItemDefinition ViewHistoryMenuItem = new CommandMenuItemDefinition<ViewHistoryCommandDefinition>(
             MainMenu.MenuDefinitions.ViewToolsMenuGroup, 5);
     }
 }


### PR DESCRIPTION
In another project, I have a "DEBUG" menu which I only desire visibility of when there's a debugger attached. This exposes functionality which facilitates this within Gemini.

The existing Exclude MenuDefinition support is not enough, because there's no conditionality to them, and I did not want to limit my "DEBUG" menu support to only `#if DEBUG` (sometimes you have to debug Release! Or modules are not built with the same configs). The optional predicate now exposed on menu definitions is passed the `this` reference, so the predicate can use additional immediate context if other people find use out of this.

This is "dynamic" in that the predicate is evaluated at menu build time. This seemed like the Keep It Simple, Stupid way of going about this, rather than trying to get too fancy with some complicated system which dynamically hides or removes/adds menu items _after_ IMenuBuilder has ran its course.

Additional thoughts for the future:
  * Could be useful for IMenu to support a RebuildMenuBar method?