### PR TITLE
Add new virtual method PopulateAssembly to customize assemblies import

### DIFF
--- a/src/Gemini/AppBootstrapper.cs
+++ b/src/Gemini/AppBootstrapper.cs
@@ -86,19 +86,7 @@ namespace Gemini
                 AssemblySource.Instance.AddRange(PublishSingleFileBypassAssemblies);
             }
 
-            // If these paths are different, it suggests this is a .netcoreapp3.1 PublishSingleFile,
-            // which extracts files to the Temp directory (AppContext.BaseDirectory).
-            // In .NET5+, the files are NOT extracted, unless IncludeAllContentForSelfExtract is set in the .pubxml.
-            // See https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file#other-considerations
-            string currentWorkingDir = Path.GetDirectoryName(Path.GetFullPath(@"./"));
-            string baseDirectory = Path.GetDirectoryName(Path.GetFullPath(AppContext.BaseDirectory));
-
-            // Add all assemblies to AssemblySource (using a temporary DirectoryCatalog).
-            PopulateAssemblySourceUsingDirectoryCatalog(currentWorkingDir);
-            if (currentWorkingDir != baseDirectory)
-            {
-                PopulateAssemblySourceUsingDirectoryCatalog(baseDirectory);
-            }
+            PopulateAssemblySource();
 
             // Prioritise the executable assembly. This allows the client project to override exports, including IShell.
             // The client project can override SelectAssemblies to choose which assemblies are prioritised.
@@ -123,6 +111,23 @@ namespace Gemini
             batch.AddExportedValue(mainCatalog);
 
             Container.Compose(batch);
+        }
+
+        protected virtual void PopulateAssemblySource()
+        {
+            // If these paths are different, it suggests this is a .netcoreapp3.1 PublishSingleFile,
+            // which extracts files to the Temp directory (AppContext.BaseDirectory).
+            // In .NET5+, the files are NOT extracted, unless IncludeAllContentForSelfExtract is set in the .pubxml.
+            // See https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file#other-considerations
+            string currentWorkingDir = Path.GetDirectoryName(Path.GetFullPath(@"./"));
+            string baseDirectory = Path.GetDirectoryName(Path.GetFullPath(AppContext.BaseDirectory));
+
+            // Add all assemblies to AssemblySource (using a temporary DirectoryCatalog).
+            PopulateAssemblySourceUsingDirectoryCatalog(currentWorkingDir);
+            if (currentWorkingDir != baseDirectory)
+            {
+                PopulateAssemblySourceUsingDirectoryCatalog(baseDirectory);
+            }
         }
 
         protected void PopulateAssemblySourceUsingDirectoryCatalog(string path)


### PR DESCRIPTION
The default import strategy of Gemini is to load all the assemblies next to executables and setup the composition with the contained imports.
It's a good approach but it can come with performance issues depending of the number and the nature of the assemblies.

In my case, it became a problem when I did a self-contained build for a specific runtime identifier. This add many assemblies next to the executable, including heavy ones, and my application startup became way slower.

That's why I suggest to move the code populating the AssemblySource into a virtual method so each Gemini applications can implement their own alternative approach to populate AssemblySource if they want. This allowed me to target or ignore assemblies depending on my own rules and the startup is now 10 times quicker.