### PR TITLE
Fix cases of readonly on [Import]'s

### DIFF
--- a/src/Gemini.Demo/Modules/Home/Commands/ViewHomeCommandHandler.cs
+++ b/src/Gemini.Demo/Modules/Home/Commands/ViewHomeCommandHandler.cs
@@ -1,28 +1,17 @@
-using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Caliburn.Micro;
 using Gemini.Demo.Modules.Home.ViewModels;
-using Gemini.Framework;
 using Gemini.Framework.Commands;
-using Gemini.Framework.Services;
-using Gemini.Framework.Threading;
+using Gemini.Framework.Results;
 
 namespace Gemini.Demo.Modules.Home.Commands
 {
     [CommandHandler]
     public class ViewHomeCommandHandler : CommandHandlerBase<ViewHomeCommandDefinition>
     {
-        private readonly IShell _shell;
-
-        [ImportingConstructor]
-        public ViewHomeCommandHandler(IShell shell)
+        public override async Task Run(Command command)
         {
-            _shell = shell;
-        }
-
-        public override Task Run(Command command)
-        {
-            return _shell.OpenDocumentAsync((IDocument) IoC.GetInstance(typeof(HomeViewModel), null));
+            await Show.Document<HomeViewModel>().ExecuteAsync();
         }
     }
 }

--- a/src/Gemini/Framework/Results/OpenDocumentResult.cs
+++ b/src/Gemini/Framework/Results/OpenDocumentResult.cs
@@ -6,53 +6,54 @@ using Gemini.Modules.Shell.Commands;
 
 namespace Gemini.Framework.Results
 {
-	public class OpenDocumentResult : OpenResultBase<IDocument>
-	{
-		private readonly IDocument _editor;
-		private readonly Type _editorType;
-		private readonly string _path;
+    public class OpenDocumentResult : OpenResultBase<IDocument>
+    {
+        private readonly IDocument _editor;
+        private readonly Type _editorType;
+        private readonly string _path;
 
 #pragma warning disable 649
-        [Import]
-		private readonly IShell _shell;
+#pragma warning disable IDE0044 // Add readonly modifier
+        [Import] private IShell _shell;
+#pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning restore 649
 
         public OpenDocumentResult(IDocument editor)
-		{
-			_editor = editor;
-		}
+        {
+            _editor = editor;
+        }
 
-		public OpenDocumentResult(string path)
-		{
-			_path = path;
-		}
+        public OpenDocumentResult(string path)
+        {
+            _path = path;
+        }
 
-		public OpenDocumentResult(Type editorType)
-		{
-			_editorType = editorType;
-		}
+        public OpenDocumentResult(Type editorType)
+        {
+            _editorType = editorType;
+        }
 
-		public override void Execute(CoroutineExecutionContext context)
-		{
-			var editor = _editor ??
-				(string.IsNullOrEmpty(_path)
-					? (IDocument)IoC.GetInstance(_editorType, null)
-					:  GetEditor(_path));
+        public override void Execute(CoroutineExecutionContext context)
+        {
+            var editor = _editor ??
+                (string.IsNullOrEmpty(_path)
+                    ? (IDocument)IoC.GetInstance(_editorType, null)
+                    :  GetEditor(_path));
 
-			if (editor == null)
-			{
-				OnCompleted(null, true);
-				return;
-			}
+            if (editor == null)
+            {
+                OnCompleted(null, true);
+                return;
+            }
 
-			if (_setData != null)
-				_setData(editor);
+            if (_setData != null)
+                _setData(editor);
 
-			if (_onConfigure != null)
-				_onConfigure(editor);
+            if (_onConfigure != null)
+                _onConfigure(editor);
 
-			editor.Deactivated += (s, e) =>
-			{
+            editor.Deactivated += (s, e) =>
+            {
                 if (e.WasClosed)
                 {
                     if (_onShutDown != null)
@@ -62,17 +63,17 @@ namespace Gemini.Framework.Results
                 return System.Threading.Tasks.Task.CompletedTask;
             };
 
-			_shell
+            _shell
                 .OpenDocumentAsync(editor)
                 .ContinueWith(t =>
                 {
                     OnCompleted(null, false);
                 });
-		}
+        }
 
-		private static IDocument GetEditor(string path)
-		{
-		    return OpenFileCommandHandler.GetEditor(path).Result;
-		}
-	}
+        private static IDocument GetEditor(string path)
+        {
+            return OpenFileCommandHandler.GetEditor(path).Result;
+        }
+    }
 }

--- a/src/Gemini/Framework/Results/ShowToolResult.cs
+++ b/src/Gemini/Framework/Results/ShowToolResult.cs
@@ -5,38 +5,38 @@ using Gemini.Framework.Services;
 
 namespace Gemini.Framework.Results
 {
-	public class ShowToolResult<TTool> : OpenResultBase<TTool>
-		where TTool : ITool
-	{
-		private readonly Func<TTool> _toolLocator = () => IoC.Get<TTool>();
+    public class ShowToolResult<TTool> : OpenResultBase<TTool>
+        where TTool : ITool
+    {
+        private readonly Func<TTool> _toolLocator = () => IoC.Get<TTool>();
 
 #pragma warning disable 649
-        [Import]
-		private readonly IShell _shell;
+#pragma warning disable IDE0044 // Add readonly modifier
+        [Import] private IShell _shell;
+#pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning restore 649
 
         public ShowToolResult()
-		{
-			
-		}
+        {
+        }
 
-		public ShowToolResult(TTool tool)
-		{
-			_toolLocator = () => tool;
-		}
+        public ShowToolResult(TTool tool)
+        {
+            _toolLocator = () => tool;
+        }
 
-		public override void Execute(CoroutineExecutionContext context)
-		{
-			var tool = _toolLocator();
+        public override void Execute(CoroutineExecutionContext context)
+        {
+            var tool = _toolLocator();
 
-			if (_setData != null)
-				_setData(tool);
+            if (_setData != null)
+                _setData(tool);
 
-			if (_onConfigure != null)
-				_onConfigure(tool);
+            if (_onConfigure != null)
+                _onConfigure(tool);
 
-			tool.Deactivated += (s, e) =>
-			{
+            tool.Deactivated += (s, e) =>
+            {
                 if (e.WasClosed)
                 {
                     if (_onShutDown != null)
@@ -48,7 +48,7 @@ namespace Gemini.Framework.Results
                 return System.Threading.Tasks.Task.CompletedTask;
             };
 
-			_shell.ShowTool(tool);
-		}
-	}
+            _shell.ShowTool(tool);
+        }
+    }
 }

--- a/src/Gemini/Modules/Toolbox/Commands/ViewToolboxCommandHandler.cs
+++ b/src/Gemini/Modules/Toolbox/Commands/ViewToolboxCommandHandler.cs
@@ -1,26 +1,16 @@
-﻿using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Caliburn.Micro;
 using Gemini.Framework.Commands;
-using Gemini.Framework.Services;
-using Gemini.Framework.Threading;
+using Gemini.Framework.Results;
 
 namespace Gemini.Modules.Toolbox.Commands
 {
     [CommandHandler]
     public class ViewToolboxCommandHandler : CommandHandlerBase<ViewToolboxCommandDefinition>
     {
-        private readonly IShell _shell;
-
-        [ImportingConstructor]
-        public ViewToolboxCommandHandler(IShell shell)
+        public override async Task Run(Command command)
         {
-            _shell = shell;
-        }
-
-        public override Task Run(Command command)
-        {
-            _shell.ShowTool<IToolbox>();
-            return TaskUtility.Completed;
+            await Show.Tool<IToolbox>().ExecuteAsync();
         }
     }
 }


### PR DESCRIPTION
Both OpenDocumentResult and ShowToolResult imported IShell but their member variable was set to readonly, which resulted in a composition exception (member is not writable, see below). They are no longer readonly.

Additionally. no code was actually making use of the Show.Document/Tool helpers, which is likely how this went uncaught, despite the README.md providing an example of it for the HomeViewModel. ViewHome and ViewToolboxCommandHandler now use Show class instead of importing IShell themselves.

```
The composition produced a single composition error. The root cause is provided below. Review the CompositionException.Errors property for more detailed information.

1) Cannot set the value of 'Gemini.Framework.Results.OpenDocumentResult._shell' because the member is not writable. If the member is a property, it must have an accessible setter; otherwise, if it is a field, it must not be read-only.

Resulting in: Cannot activate part 'Gemini.Framework.Results.OpenDocumentResult'.
Element: Gemini.Framework.Results.OpenDocumentResult -->  Gemini.Framework.Results.OpenDocumentResult
```