### PR TITLE
Fix RelayCommand

### DIFF
--- a/src/Gemini/Framework/RelayCommand.cs
+++ b/src/Gemini/Framework/RelayCommand.cs
@@ -1,57 +1,58 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Windows.Input;
 
 namespace Gemini.Framework
 {
-	/// <summary>
-	/// Used where Caliburn.Micro needs to be interfaced to ICommand.
-	/// </summary>
-	public class RelayCommand : ICommand
-	{
-		#region Fields
+    /// <summary>
+    /// Used where Caliburn.Micro needs to be interfaced to ICommand.
+    /// </summary>
+    [Obsolete("Use generic version", false)]
+    public class RelayCommand : ICommand
+    {
+        #region Fields
 
-		private readonly Action<object> _execute;
-		private readonly Predicate<object> _canExecute;
+        private readonly Action<object> _execute;
+        private readonly Predicate<object> _canExecute;
 
-		#endregion // Fields
+        #endregion // Fields
 
-		#region Constructors
+        #region Constructors
 
-		public RelayCommand(Action<object> execute)
-			: this(execute, null)
-		{
-		}
+        public RelayCommand(Action<object> execute)
+            : this(execute, null)
+        {
+        }
 
-		public RelayCommand(Action<object> execute, Predicate<object> canExecute)
-		{
-			if (execute == null)
-				throw new ArgumentNullException("execute");
+        public RelayCommand(Action<object> execute, Predicate<object> canExecute)
+        {
+            if (execute == null)
+                throw new ArgumentNullException("execute");
 
-			_execute = execute;
-			_canExecute = canExecute;
-		}
-		#endregion // Constructors
+            _execute = execute;
+            _canExecute = canExecute;
+        }
+        #endregion // Constructors
 
-		#region ICommand Members
+        #region ICommand Members
 
-		[DebuggerStepThrough]
-		public bool CanExecute(object parameter)
-		{
-			return _canExecute == null || _canExecute(parameter);
-		}
+        [DebuggerStepThrough]
+        public bool CanExecute(object parameter)
+        {
+            return _canExecute == null || _canExecute(parameter);
+        }
 
-		public event EventHandler CanExecuteChanged
-		{
-			add { CommandManager.RequerySuggested += value; }
-			remove { CommandManager.RequerySuggested -= value; }
-		}
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
 
-		public void Execute(object parameter)
-		{
-			_execute(parameter);
-		}
+        public void Execute(object parameter)
+        {
+            _execute(parameter);
+        }
 
-		#endregion // ICommand Members
-	}
+        #endregion // ICommand Members
+    }
 }

--- a/src/Gemini/Framework/RelayCommandGeneric.cs
+++ b/src/Gemini/Framework/RelayCommandGeneric.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Diagnostics;
+using System.Windows.Input;
+
+namespace Gemini.Framework
+{
+    /// <summary>
+    /// Used where Caliburn.Micro needs to be interfaced to ICommand.
+    /// </summary>
+    public class RelayCommand<T> : ICommand
+    {
+        #region Fields
+
+        private readonly Action<T> _execute;
+        private readonly Predicate<T> _canExecute;
+
+        #endregion // Fields
+
+        #region Constructors
+
+        public RelayCommand(Action<T> execute)
+            : this(execute, null)
+        {
+        }
+
+        public RelayCommand(Action<T> execute, Predicate<T> canExecute)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+        #endregion // Constructors
+
+        #region ICommand Members
+
+        [DebuggerStepThrough]
+        public bool CanExecute(object parameter)
+        {
+            if (_canExecute == null)
+                return true;
+
+            return _canExecute == null ? true : _canExecute((T)parameter);
+        }
+
+        public event EventHandler CanExecuteChanged
+        {
+            add
+            {
+                if (_canExecute != null)
+                {
+                    CommandManager.RequerySuggested += value;
+                }
+            }
+            remove
+            {
+                if (_canExecute != null)
+                {
+                    CommandManager.RequerySuggested -= value;
+                }
+            }
+        }
+
+        public void Execute(object parameter)
+        {
+            _execute((T)parameter);
+        }
+
+        #endregion // ICommand Members
+    }
+}

--- a/src/Gemini/Modules/Toolbox/ViewModels/ToolboxViewModel.cs
+++ b/src/Gemini/Modules/Toolbox/ViewModels/ToolboxViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -17,11 +17,11 @@ namespace Gemini.Modules.Toolbox.ViewModels
     public class ToolboxViewModel : Tool, IToolbox
     {
 
-        private RelayCommand _searchCommand;
+        private RelayCommand<string> _searchCommand;
 
         public ICommand SearchCommand
         {
-            get { return _searchCommand == null ? _searchCommand = new RelayCommand(a => Search(a as string)) : _searchCommand; }
+            get { return _searchCommand == null ? _searchCommand = new RelayCommand<string>(Search) : _searchCommand; }
         }
 
         private readonly IToolboxService _toolboxService;


### PR DESCRIPTION
It's nice that Gemini provides a `RelayCommand`, the absence of which is rather annoying in Caliburn.Micro. But for some reason `RelayCommand` uses hard-coded `Action<object>` and `Predicate<object>` delegates. This PR makes ` RelayCommand ` more convenient to use by adding generic version.