### PR TITLE
Avoid full repaint when settings are applied and theme is unchanged

### DIFF
--- a/src/Gemini/Framework/Themes/ThemeManager.cs
+++ b/src/Gemini/Framework/Themes/ThemeManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original source code from the Wide framework:
  * https://github.com/chandramouleswaran/Wide
  * 
@@ -57,6 +57,11 @@ namespace Gemini.Framework.Themes
             var mainWindow = Application.Current.MainWindow;
             if (mainWindow == null)
                 return false;
+
+            if (CurrentTheme == theme)
+            {
+                return true; // Nothing to do, avoid full repaint of mainwindow
+            }
 
             CurrentTheme = theme;
 


### PR DESCRIPTION
When settings are applied the Main Window flicker. This PR avoids the repaint when theme is unchanged avoiding the flicker.