### PR TITLE
Settings async

### DIFF
--- a/src/Gemini/Modules/Settings/ISettingsEditor.cs
+++ b/src/Gemini/Modules/Settings/ISettingsEditor.cs
@@ -1,10 +1,7 @@
-﻿namespace Gemini.Modules.Settings
+namespace Gemini.Modules.Settings
 {
-    public interface ISettingsEditor
+    public interface ISettingsEditor : ISettingsEditorBase
     {
-        string SettingsPageName { get; }
-        string SettingsPagePath { get; }
-
         void ApplyChanges();
     }
 }

--- a/src/Gemini/Modules/Settings/ISettingsEditor.cs
+++ b/src/Gemini/Modules/Settings/ISettingsEditor.cs
@@ -1,7 +1,10 @@
 namespace Gemini.Modules.Settings
 {
-    public interface ISettingsEditor : ISettingsEditorBase
+    public interface ISettingsEditor
     {
+        string SettingsPageName { get; }
+        string SettingsPagePath { get; }
+
         void ApplyChanges();
     }
 }

--- a/src/Gemini/Modules/Settings/ISettingsEditorAsync.cs
+++ b/src/Gemini/Modules/Settings/ISettingsEditorAsync.cs
@@ -2,8 +2,11 @@ using System.Threading.Tasks;
 
 namespace Gemini.Modules.Settings
 {
-    public interface ISettingsEditorAsync : ISettingsEditorBase
+    public interface ISettingsEditorAsync
     {
+        string SettingsPageName { get; }
+        string SettingsPagePath { get; }
+
         Task ApplyChangesAsync();
     }
 }

--- a/src/Gemini/Modules/Settings/ISettingsEditorAsync.cs
+++ b/src/Gemini/Modules/Settings/ISettingsEditorAsync.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Gemini.Modules.Settings
+{
+    public interface ISettingsEditorAsync : ISettingsEditorBase
+    {
+        Task ApplyChangesAsync();
+    }
+}

--- a/src/Gemini/Modules/Settings/ISettingsEditorBase.cs
+++ b/src/Gemini/Modules/Settings/ISettingsEditorBase.cs
@@ -1,0 +1,8 @@
+namespace Gemini.Modules.Settings
+{
+    public interface ISettingsEditorBase
+    {
+        string SettingsPageName { get; }
+        string SettingsPagePath { get; }
+    }
+}

--- a/src/Gemini/Modules/Settings/ISettingsEditorBase.cs
+++ b/src/Gemini/Modules/Settings/ISettingsEditorBase.cs
@@ -1,8 +1,0 @@
-namespace Gemini.Modules.Settings
-{
-    public interface ISettingsEditorBase
-    {
-        string SettingsPageName { get; }
-        string SettingsPagePath { get; }
-    }
-}

--- a/src/Gemini/Modules/Settings/ViewModels/SettingsEditorWrapper.cs
+++ b/src/Gemini/Modules/Settings/ViewModels/SettingsEditorWrapper.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+
+namespace Gemini.Modules.Settings.ViewModels
+{
+    internal sealed class SettingsEditorWrapper : ISettingsEditorAsync
+    {
+        private readonly ISettingsEditor _editor;
+
+        public SettingsEditorWrapper(ISettingsEditor editor)
+        {
+            _editor = editor;
+        }
+
+        public string SettingsPageName => _editor.SettingsPageName;
+
+        public string SettingsPagePath => _editor.SettingsPagePath;
+
+        public ISettingsEditor ViewModel => _editor;
+
+        public Task ApplyChangesAsync()
+        {
+            _editor.ApplyChanges();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Gemini/Modules/Settings/ViewModels/SettingsPageViewModel.cs
+++ b/src/Gemini/Modules/Settings/ViewModels/SettingsPageViewModel.cs
@@ -7,11 +7,13 @@ namespace Gemini.Modules.Settings.ViewModels
         public SettingsPageViewModel()
         {
             Children = new List<SettingsPageViewModel>();
-            Editors = new List<ISettingsEditor>();
+            Editors = new List<ISettingsEditorBase>();
         }
 
         public string Name { get; set; }
-        public List<ISettingsEditor> Editors { get; private set; }
-        public List<SettingsPageViewModel> Children { get; internal set; }
+
+        public List<ISettingsEditorBase> Editors { get; }
+
+        public List<SettingsPageViewModel> Children { get; }
     }
 }

--- a/src/Gemini/Modules/Settings/ViewModels/SettingsPageViewModel.cs
+++ b/src/Gemini/Modules/Settings/ViewModels/SettingsPageViewModel.cs
@@ -7,12 +7,12 @@ namespace Gemini.Modules.Settings.ViewModels
         public SettingsPageViewModel()
         {
             Children = new List<SettingsPageViewModel>();
-            Editors = new List<ISettingsEditorBase>();
+            Editors = new List<object>();
         }
 
         public string Name { get; set; }
 
-        public List<ISettingsEditorBase> Editors { get; }
+        public List<object> Editors { get; } // ISettingsEditor or ISettingsEditorAsync
 
         public List<SettingsPageViewModel> Children { get; }
     }

--- a/src/Gemini/Modules/Settings/ViewModels/SettingsViewModel.cs
+++ b/src/Gemini/Modules/Settings/ViewModels/SettingsViewModel.cs
@@ -14,8 +14,7 @@ namespace Gemini.Modules.Settings.ViewModels
     [PartCreationPolicy (CreationPolicy.NonShared)]
     public class SettingsViewModel : WindowBase
     {
-        private IEnumerable<ISettingsEditor> _settingsEditors;
-        private IEnumerable<ISettingsEditorAsync> _settingsEditorsAsync;
+        private IEnumerable<ISettingsEditorAsync> _settingsEditors;
         private SettingsPageViewModel _selectedPage;
 
         public SettingsViewModel()
@@ -40,12 +39,10 @@ namespace Gemini.Modules.Settings.ViewModels
             await base.OnInitializeAsync(cancellationToken);
 
             var pages = new List<SettingsPageViewModel>();
-            _settingsEditors = IoC.GetAll<ISettingsEditor>();
-            _settingsEditorsAsync = IoC.GetAll<ISettingsEditorAsync>();
 
-            var allSettingsEditor = _settingsEditors.Cast<ISettingsEditorBase>().Concat(_settingsEditorsAsync);
+            _settingsEditors = IoC.GetAll<ISettingsEditorAsync>().Concat(IoC.GetAll<ISettingsEditor>().Select(e => new SettingsEditorWrapper(e)));
 
-            foreach (var settingsEditor in allSettingsEditor)
+            foreach (var settingsEditor in _settingsEditors)
             {
                 var parentCollection = GetParentCollection(settingsEditor, pages);
 
@@ -53,14 +50,11 @@ namespace Gemini.Modules.Settings.ViewModels
 
                 if (page == null)
                 {
-                    page = new SettingsPageViewModel
-                    {
-                        Name = settingsEditor.SettingsPageName,
-                    };
+                    page = new SettingsPageViewModel { Name = settingsEditor.SettingsPageName };
                     parentCollection.Add(page);
                 }
 
-                page.Editors.Add(settingsEditor);
+                page.Editors.Add(settingsEditor is SettingsEditorWrapper wrapper ? (object)wrapper.ViewModel : (object)settingsEditor);
             }
 
             Pages = pages;
@@ -79,7 +73,7 @@ namespace Gemini.Modules.Settings.ViewModels
             return GetFirstLeafPageRecursive(firstPage.Children);
         }
 
-        private List<SettingsPageViewModel> GetParentCollection(ISettingsEditorBase settingsEditor,
+        private List<SettingsPageViewModel> GetParentCollection(ISettingsEditorAsync settingsEditor,
             List<SettingsPageViewModel> pages)
         {
             if (string.IsNullOrEmpty(settingsEditor.SettingsPagePath))
@@ -95,7 +89,7 @@ namespace Gemini.Modules.Settings.ViewModels
 
                 if (page == null)
                 {
-                    page = new SettingsPageViewModel {Name = pathElement};
+                    page = new SettingsPageViewModel { Name = pathElement };
                     pages.Add(page);
                 }
 
@@ -107,14 +101,9 @@ namespace Gemini.Modules.Settings.ViewModels
 
         public async Task SaveChanges()
         {
-            foreach (var settingsEditor in _settingsEditorsAsync)
-            {
-                await settingsEditor.ApplyChangesAsync();
-            }
-
             foreach (var settingsEditor in _settingsEditors)
             {
-                settingsEditor.ApplyChanges();
+                await settingsEditor.ApplyChangesAsync();
             }
 
             await TryCloseAsync(true);


### PR DESCRIPTION
Settings editor may need I/O operation to apply settings, and should use the async way. 

This PR add a method ApplyChangesAsync in a specific ISettingsEditorAsync interface.
Existing interface is kept to avoid breaking changes. 

Implementation have been done in a binary backward compatible way for implementations of ISettingsEditor (as they may come from a NuGet that might not be possible to rebuild).

A breaking change have been made SettingsPageViewModel.Editors (only used by View/Xaml file), no one on github have a an access to SettingsPageViewModel, so it seems a safe change.