### PR TITLE
Fix document list menu

### DIFF
--- a/src/Gemini/Themes/VS2013/Controls/Menu.xaml
+++ b/src/Gemini/Themes/VS2013/Controls/Menu.xaml
@@ -13,7 +13,8 @@
 -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:xcad="https://github.com/Dirkster99/AvalonDock">
+                    xmlns:xcad="https://github.com/Dirkster99/AvalonDock"
+                    xmlns:avalonDockConverters="clr-namespace:AvalonDock.Converters;assembly=AvalonDock">
 
     <Geometry x:Key="Checkmark">
         M 0,5.1 L 1.7,5.2 L 3.4,7.1 L 8,0.4 L 9.2,0 L 3.3,10.8 Z
@@ -377,5 +378,10 @@
     <Style TargetType="xcad:MenuItemEx" BasedOn="{StaticResource MetroMenuItem}">
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="HeaderTemplate" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplate}" />
+        <Setter Property="HeaderTemplateSelector" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplateSelector}" />
+        <Setter Property="IconTemplate" Value="{Binding Path=Root.Manager.IconContentTemplate}" />
+        <Setter Property="IconTemplateSelector" Value="{Binding Path=Root.Manager.IconContentTemplateSelector}" />
+        <Setter Property="Command" Value="{Binding Path=., Converter={avalonDockConverters:ActivateCommandLayoutItemFromLayoutModelConverter}}" />
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
The menu in document tab header did not work, document title was missing, and click on menu item has no effect.

This PR fixes the title and command binding. Menu is now fully functional.

Before this PR:

![image](https://github.com/tgjones/gemini/assets/33651126/4b19643b-3284-4f05-bc8d-7a5db9923f25)

After this PR:

![image](https://github.com/tgjones/gemini/assets/33651126/62c7d2d4-1c39-469b-81b1-211606932933)
